### PR TITLE
Fix/fhir connection error handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "lru-cache": "^11.3.5"
       },
       "devDependencies": {
-        "@outburn/structure-navigator": "^1.9.4",
+        "@outburn/structure-navigator": "^1.9.5",
         "@outburn/types": "^0.1.0",
         "@types/json5": "^0.0.30",
         "@types/node": "^25.6.0",
@@ -43,7 +43,7 @@
       },
       "peerDependencies": {
         "@outburn/fhir-client": "^1.5.0",
-        "@outburn/structure-navigator": "^1.9.4",
+        "@outburn/structure-navigator": "^1.9.5",
         "@outburn/types": "^0.1.0 || ^0.2.0",
         "fhir-package-explorer": "^1.9.3",
         "fhir-snapshot-generator": "^2.3.1",
@@ -866,13 +866,13 @@
       }
     },
     "node_modules/@outburn/structure-navigator": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@outburn/structure-navigator/-/structure-navigator-1.9.4.tgz",
-      "integrity": "sha512-a9DkfMKMwb9Ha+tFgQBM7+Yfzpnyt9XCsDPBRk71cQm03n4d7uL64B8AEVGSi8HeXOhFqXcFMhWnOlV8Nc5XZg==",
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/@outburn/structure-navigator/-/structure-navigator-1.9.5.tgz",
+      "integrity": "sha512-eggLmoglGIq3UumzCuddZKZtTX0ZqTW8NsprwNoWtQlm/bO3arWvyNQm6iLTe4yN3/vdXKDlIeeQX2JvzUBCsA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "lru-cache": "^11.2.7"
+        "lru-cache": "^11.3.5"
       },
       "peerDependencies": {
         "@outburn/types": "^0.1.0 || ^0.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fumifier",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fumifier",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "license": "AGPL-3.0",
       "dependencies": {
         "lru-cache": "^11.3.5"

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "lru-cache": "^11.3.5"
   },
   "devDependencies": {
-    "@outburn/structure-navigator": "^1.9.4",
+    "@outburn/structure-navigator": "^1.9.5",
     "@outburn/types": "^0.1.0",
     "@types/json5": "^0.0.30",
     "@types/node": "^25.6.0",
@@ -123,7 +123,7 @@
   },
   "peerDependencies": {
     "@outburn/fhir-client": "^1.5.0",
-    "@outburn/structure-navigator": "^1.9.4",
+    "@outburn/structure-navigator": "^1.9.5",
     "@outburn/types": "^0.1.0 || ^0.2.0",
     "fhir-package-explorer": "^1.9.3",
     "fhir-snapshot-generator": "^2.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fumifier",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Fumifier is the core FLASH DSL engine inside FUME - It parses, compiles and executes FHIR related transformation logic expressed with FUME's specialized syntax (FLASH) and applies it to JSON data structures.",
   "author": "Outburn Ltd.",
   "main": "./dist/index.cjs",

--- a/src/fumifier.js
+++ b/src/fumifier.js
@@ -112,7 +112,7 @@ class FumifierError extends Error {
 }
 
 /**
- * @typedef {import('@outburn/structure-navigator').FhirStructureNavigator} FhirStructureNavigator
+ * @typedef {import('@outburn/structure-navigator').FhirStructureNavigatorInterface} FhirStructureNavigatorInterface
  */
 
 /**
@@ -151,7 +151,7 @@ class FumifierError extends Error {
 /**
  * @typedef FumifierOptions
  * @property {boolean} [recover] Attempt to recover on parse error.
- * @property {FhirStructureNavigator} [navigator] FHIR structure navigator used to resolve FLASH constructs.
+ * @property {FhirStructureNavigatorInterface} [navigator] FHIR structure navigator used to resolve FLASH constructs.
  * @property {FhirTerminologyRuntime} [terminologyRuntime] FHIR terminology runtime used for valueset expansions.
  * @property {AstCacheInterface} [astCache] Optional AST cache implementation for parsed expressions. Defaults to shared LRU cache.
  * @property {MappingCacheInterface} [mappingCache] Optional mapping repository for named expressions.

--- a/src/fumifier.js
+++ b/src/fumifier.js
@@ -2458,6 +2458,10 @@ var fumifier = (function() {
         return environment.lookup(Symbol.for('fumifier.__fhirClient'));
       }
 
+      if (activeConnection.client) {
+        return activeConnection.client;
+      }
+
       const connectionResolver = environment.lookup(Symbol.for('fumifier.__connectionResolver'));
       if (!connectionResolver) {
         return environment.lookup(Symbol.for('fumifier.__fhirClient'));
@@ -2475,17 +2479,43 @@ var fumifier = (function() {
     env.bind('resolve', defineFunction(wrappers.resolve, '<s-o?o?:o>'));
     env.bind('literal', defineFunction(wrappers.literal, '<s-o?o?:s>'));
     env.bind('useFhirServer', defineFunction(function(target, config) {
+      const currentFhirServerSymbol = Symbol.for('fumifier.__currentFhirServer');
+
       if (typeof target === 'undefined') {
-        this.environment.bind(Symbol.for('fumifier.__currentFhirServer'), null);
+        this.environment.bind(currentFhirServerSymbol, null);
         return undefined;
+      }
+
+      const connectionResolver = this.environment.lookup(Symbol.for('fumifier.__connectionResolver'));
+      if (!connectionResolver) {
+        throw new FumifierError('D3200', undefined, {
+          target,
+          stack: (new Error()).stack
+        });
+      }
+
+      let client;
+      try {
+        client = connectionResolver(target, config);
+      } catch (err) {
+        if (typeof err?.code === 'string' && /^[DSTF]/.test(err.code)) {
+          throw err;
+        }
+
+        throw new FumifierError('D3201', undefined, {
+          target,
+          sourceMessage: err?.message || String(err),
+          sourceError: err,
+          stack: err?.stack || (new Error()).stack
+        });
       }
 
       if (typeof config === 'undefined') {
-        this.environment.bind(Symbol.for('fumifier.__currentFhirServer'), { target });
+        this.environment.bind(currentFhirServerSymbol, { target, client });
         return undefined;
       }
 
-      this.environment.bind(Symbol.for('fumifier.__currentFhirServer'), { target, config });
+      this.environment.bind(currentFhirServerSymbol, { target, config, client });
       return undefined;
     }, '<s?o?:u>'));
   }

--- a/src/utils/createFhirFetchers.js
+++ b/src/utils/createFhirFetchers.js
@@ -6,8 +6,17 @@ License: See the LICENSE file included with this package for the terms that appl
 */
 
 
+
+/**
+ * @typedef {import('@outburn/structure-navigator').FhirStructureNavigatorInterface} FhirStructureNavigatorInterface
+ */
+
+/**
+ * @typedef {import('fhir-terminology-runtime').FhirTerminologyRuntime} FhirTerminologyRuntime
+ */
+
 /** Takes a FHIR Structure Navigator and FHIR Terminology Runtime and returns helper functions used to fetch FHIR semantic data
- * @param {FhirStructureNavigator} navigator - FHIR structure navigator
+ * @param {FhirStructureNavigatorInterface} navigator - FHIR structure navigator
  * @param {FhirTerminologyRuntime} terminologyRuntime - FHIR terminology runtime for valueset expansions
  * @returns {Object} An object containing functions to fetch FHIR data
  * @property {Function} getElement - Function to fetch element definitions

--- a/src/utils/errorCodes.js
+++ b/src/utils/errorCodes.js
@@ -176,6 +176,8 @@ const errorCodes = {
   "D3139": "The $single() function expected exactly 1 matching result.  Instead it matched 0.",
   "D3140": "Malformed URL passed to ${{{functionName}}}(): {{value}}",
   "D3141": "{{{message}}}",
+  "D3200": "Cannot switch FHIR server to {{target}}: connection resolver is not configured.",
+  "D3201": "Failed to switch FHIR server to {{target}}: {{{sourceMessage}}}",
   "F0001": "Failed to extract root FHIR package context. This may hinder AST mobility. FHIR Package Explorer < v1.5.0 doesn't support this operation.",
   "F1000": "FLASH blocks are present in the expression, but no FHIR Structure Navigator was provided. Cannot process FHIR conformance.",
   "F1003": "Invalid FHIR type/profile identifier after `InstanceOf:`",

--- a/src/utils/resolveDefinitions.js
+++ b/src/utils/resolveDefinitions.js
@@ -13,6 +13,14 @@ import { populateMessage } from './errorCodes.js';
 import fn from './functions.js';
 
 /**
+ * @typedef {import('@outburn/structure-navigator').FhirStructureNavigatorInterface} FhirStructureNavigatorInterface
+ */
+
+/**
+ * @typedef {import('fhir-terminology-runtime').FhirTerminologyRuntime} FhirTerminologyRuntime
+ */
+
+/**
  * Centralized recoverable error handling helper.
  * @param {Object} base - base error object without position information
  * @param {Object[]} positions - Array of position containing objects pointing to the source of the error
@@ -70,7 +78,7 @@ function handleRecoverableError(base, positions, recover, errors, errObj) {
  * After parsing a Fumifier expression and running it through processAst,
  * if the expression has FLASH it will be flagged as such and passed here for FHIR definition resolution and processing.
  * @param {Object} expr - Parsed Fumifier expression
- * @param {FhirStructureNavigator} navigator - FHIR structure navigator
+ * @param {FhirStructureNavigatorInterface} navigator - FHIR structure navigator
  * @param {FhirTerminologyRuntime} terminologyRuntime - FHIR terminology runtime for valueset expansions
  * @param {boolean} recover - If true, will continue processing and collect errors instead of throwing them.
  * @param {Array} errors - Array to collect errors if recover is true

--- a/test/use-fhir-server.test.js
+++ b/test/use-fhir-server.test.js
@@ -139,20 +139,77 @@ describe('$useFhirServer', function() {
     ]);
   });
 
-  it('throws when resolver cannot resolve a named connection', async function() {
+  it('throws immediately when resolver cannot resolve a named connection', async function() {
     const defaultClient = createClient(1);
 
-    const expr = await fumifier("($useFhirServer('nonExistent'); $search('Patient', {}))", {
+    const expr = await fumifier("$useFhirServer('nonExistent')", {
       fhirClient: defaultClient,
       connectionResolver: (target) => {
         throw new Error(`Unknown FHIR connection name: "${target}"`);
       }
     });
 
-    await expect(expr.evaluate({})).to.eventually.be.rejectedWith('Unknown FHIR connection name: "nonExistent"');
+    try {
+      await expr.evaluate({});
+      expect.fail('Expected evaluation to reject');
+    } catch (err) {
+      expect(err.code).to.equal('D3201');
+      expect(err.token).to.equal('useFhirServer');
+      expect(err.message).to.equal('Failed to switch FHIR server to "nonExistent": Unknown FHIR connection name: "nonExistent"');
+    }
   });
 
-  it('keeps $translateCode on terminology runtime and does not use connection resolver', async function() {
+  it('throws when a target is provided without a connection resolver', async function() {
+    const expr = await fumifier("$useFhirServer('nonExistent')");
+
+    try {
+      await expr.evaluate({});
+      expect.fail('Expected evaluation to reject');
+    } catch (err) {
+      expect(err.code).to.equal('D3200');
+      expect(err.token).to.equal('useFhirServer');
+      expect(err.message).to.equal('Cannot switch FHIR server to "nonExistent": connection resolver is not configured.');
+    }
+  });
+
+  it('resolves once at $useFhirServer and reuses the stored client for later FHIR helpers', async function() {
+    const defaultClient = createClient(1);
+    const namedClient = createClient(2);
+    const resolverCalls = [];
+
+    const expr = await fumifier("($useFhirServer('myConn'); [$search('Patient', {}).total, $capabilities().resourceType])", {
+      fhirClient: defaultClient,
+      connectionResolver: (target, config) => {
+        resolverCalls.push({ target, config });
+        return namedClient;
+      }
+    });
+
+    const result = await expr.evaluate({});
+
+    expect(result).to.deep.equal([2, 'CapabilityStatement']);
+    expect(resolverCalls).to.deep.equal([{ target: 'myConn', config: undefined }]);
+  });
+
+  it('wraps plain resolver failures with D3201 details', async function() {
+    const expr = await fumifier("$useFhirServer('myConn')", {
+      connectionResolver: () => {
+        throw new Error('boom');
+      }
+    });
+
+    try {
+      await expr.evaluate({});
+      expect.fail('Expected evaluation to reject');
+    } catch (err) {
+      expect(err.code).to.equal('D3201');
+      expect(err.token).to.equal('useFhirServer');
+      expect(err.message).to.equal('Failed to switch FHIR server to "myConn": boom');
+      expect(err.sourceMessage).to.equal('boom');
+    }
+  });
+
+  it('keeps $translateCode on terminology runtime after switching FHIR servers', async function() {
     const defaultClient = createClient(1);
     const resolverCalls = [];
     const terminologyRuntime = {
@@ -175,7 +232,7 @@ describe('$useFhirServer', function() {
 
     const result = await expr.evaluate({});
     expect(result).to.equal('mapped-code');
-    expect(resolverCalls).to.deep.equal([]);
+    expect(resolverCalls).to.deep.equal([{ target: 'myConn', config: undefined }]);
   });
 
   it('affects later object entries when the modifier is evaluated inside the object constructor', async function() {


### PR DESCRIPTION
This pull request introduces improvements and bug fixes related to FHIR server switching and client resolution in the Fumifier engine. The main changes include enhanced error handling and reporting for FHIR server connections, improved client management, and updates to type definitions for better clarity and interoperability. Additionally, dependencies have been updated for compatibility.

**FHIR Server Switching and Client Resolution:**

* The `$useFhirServer` function now throws a specific error (`D3200`) if a target is provided without a configured connection resolver, and wraps resolver failures in a new error (`D3201`) with detailed messages. This improves clarity and debuggability when switching FHIR servers. [[1]](diffhunk://#diff-37258522e00779c1dad11792df68616b4b0d132fd2cee280baa1e810869ad65aR2482-R2518) [[2]](diffhunk://#diff-31f58e36ee7011965d552befb8eeb3caf3ee80a9d8d9cdd167026ad34d8b9acdR179-R180) [[3]](diffhunk://#diff-a964559abe9e0cc160a82c0880ddcabe6bd621abc38f0f94f50887b7c0e9a530L142-R212) [[4]](diffhunk://#diff-a964559abe9e0cc160a82c0880ddcabe6bd621abc38f0f94f50887b7c0e9a530L178-R235)
* The resolved FHIR client is now stored and reused for subsequent FHIR operations, ensuring consistent behavior after switching servers. [[1]](diffhunk://#diff-37258522e00779c1dad11792df68616b4b0d132fd2cee280baa1e810869ad65aR2461-R2464) [[2]](diffhunk://#diff-a964559abe9e0cc160a82c0880ddcabe6bd621abc38f0f94f50887b7c0e9a530L178-R235)

**Type Definition and Documentation Updates:**

* All references to `FhirStructureNavigator` have been updated to `FhirStructureNavigatorInterface` in JSDoc typedefs and function signatures for improved type accuracy and compatibility. [[1]](diffhunk://#diff-37258522e00779c1dad11792df68616b4b0d132fd2cee280baa1e810869ad65aL115-R115) [[2]](diffhunk://#diff-37258522e00779c1dad11792df68616b4b0d132fd2cee280baa1e810869ad65aL154-R154) [[3]](diffhunk://#diff-ed2fd1c3d3b2fddd72c10ef35cb9cc4714d38afd6c131cb10f4f72a00ec6b9c5R9-R19) [[4]](diffhunk://#diff-025d5c4de02711e9647b71bfc2dbc21bc278a6db6fd688c253d3cab700ddd03fR15-R22) [[5]](diffhunk://#diff-025d5c4de02711e9647b71bfc2dbc21bc278a6db6fd688c253d3cab700ddd03fL73-R81)

**Dependency Updates:**

* Updated `@outburn/structure-navigator` dependency from `^1.9.4` to `^1.9.5` in both `devDependencies` and `peerDependencies` for compatibility. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L95-R95) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L126-R126)
* Bumped package version from `2.2.0` to `2.2.1`.