### PR TITLE
fix: propagate error message in diagnostics for resolver failures

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fumifier",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fumifier",
-      "version": "2.2.1",
+      "version": "2.2.2",
       "license": "AGPL-3.0",
       "dependencies": {
         "lru-cache": "^11.3.5"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fumifier",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Fumifier is the core FLASH DSL engine inside FUME - It parses, compiles and executes FHIR related transformation logic expressed with FUME's specialized syntax (FLASH) and applies it to JSON data structures.",
   "author": "Outburn Ltd.",
   "main": "./dist/index.cjs",

--- a/src/utils/diagnostics.js
+++ b/src/utils/diagnostics.js
@@ -160,6 +160,9 @@ export function push(env, entry) {
 
   // sanitize entry: remove stack from collected diagnostics
   const rest = { ...(entry || {}) };
+  if (entry instanceof Error || (typeof entry?.message === 'string' && !Object.prototype.hasOwnProperty.call(rest, 'message'))) {
+    rest.message = entry.message;
+  }
   if (Object.prototype.hasOwnProperty.call(rest, 'stack')) delete rest.stack;
 
   // dedupe: ensure we don't collect identical diagnostics multiple times

--- a/test/use-fhir-server.test.js
+++ b/test/use-fhir-server.test.js
@@ -209,6 +209,26 @@ describe('$useFhirServer', function() {
     }
   });
 
+  it('preserves the populated message in evaluateVerbose diagnostics for resolver failures', async function() {
+    const expr = await fumifier("$useFhirServer('public-hap')", {
+      connectionResolver: (target) => {
+        throw new Error(`Unknown FHIR connection name: "${target}"`);
+      }
+    });
+
+    const report = await expr.evaluateVerbose({});
+
+    expect(report.ok).to.equal(false);
+    expect(report.status).to.equal(422);
+    expect(report.diagnostics.error).to.have.lengthOf(1);
+    expect(report.diagnostics.error[0]).to.include({
+      code: 'D3201',
+      token: 'useFhirServer',
+      message: 'Failed to switch FHIR server to "public-hap": Unknown FHIR connection name: "public-hap"',
+      sourceMessage: 'Unknown FHIR connection name: "public-hap"'
+    });
+  });
+
   it('keeps $translateCode on terminology runtime after switching FHIR servers', async function() {
     const defaultClient = createClient(1);
     const resolverCalls = [];


### PR DESCRIPTION
This pull request improves error handling and diagnostics reporting, specifically ensuring that error messages are properly preserved and tested when diagnostics are collected and reported.

**Diagnostics handling improvements:**

* Updated the `push` function in `src/utils/diagnostics.js` to ensure that if an `Error` object is passed (or an object with a string `message` property), its message is explicitly copied to the diagnostics entry. This helps preserve the error message for later reporting.

**Testing enhancements:**

* Added a new test case in `test/use-fhir-server.test.js` to verify that the populated error message is preserved in the diagnostics when a resolver failure occurs in `$useFhirServer`, ensuring accurate error reporting in verbose evaluation.