### PR TITLE
Feat/list named connections

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fumifier",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fumifier",
-      "version": "2.2.2",
+      "version": "2.3.0",
       "license": "AGPL-3.0",
       "dependencies": {
         "lru-cache": "^11.3.5"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fumifier",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "description": "Fumifier is the core FLASH DSL engine inside FUME - It parses, compiles and executes FHIR related transformation logic expressed with FUME's specialized syntax (FLASH) and applies it to JSON data structures.",
   "author": "Outburn Ltd.",
   "main": "./dist/index.cjs",

--- a/src/fumifier.js
+++ b/src/fumifier.js
@@ -159,6 +159,8 @@ class FumifierError extends Error {
  * @property {FhirClient} [fhirClient] Optional FHIR client for server operations.
  * @property {(target: string, config?: FhirConnectionConfig) => FhirClient} [connectionResolver]
  *   Optional resolver used to resolve an active FHIR connection target to a client.
+ * @property {string[] | (() => string[])} [namedFhirConnectionNames]
+ *   Optional list or provider for configured named FHIR connection names.
  * @property {Record<string, any>} [bindings] Optional variable/function bindings (no signature support for functions).
  */
 
@@ -168,6 +170,8 @@ class FumifierError extends Error {
  * @property {FhirClient} [fhirClient] Override FHIR client for this evaluation only.
  * @property {(target: string, config?: FhirConnectionConfig) => FhirClient} [connectionResolver]
  *   Override connection resolver for this evaluation only.
+ * @property {string[] | (() => string[])} [namedFhirConnectionNames]
+ *   Override configured named FHIR connection names for this evaluation only.
  * @property {MappingCacheInterface} [mappingCache] Override mapping cache for this evaluation only.
  */
 
@@ -2452,6 +2456,15 @@ var fumifier = (function() {
    * @param {Object} env - The environment to bind FHIR client functions to
    */
   function bindFhirClientFunctions(env) {
+    const getNamedFhirConnectionNames = (environment) => {
+      const namesOrProvider = environment.lookup(Symbol.for('fumifier.__namedFhirConnectionNames'));
+      if (typeof namesOrProvider === 'undefined' || namesOrProvider === null) {
+        return [];
+      }
+
+      const names = isFunction(namesOrProvider) ? namesOrProvider() : namesOrProvider;
+      return Array.isArray(names) ? names.slice() : [];
+    };
     const getFhirClient = (environment) => {
       const activeConnection = environment.lookup(Symbol.for('fumifier.__currentFhirServer'));
       if (!activeConnection) {
@@ -2478,6 +2491,9 @@ var fumifier = (function() {
     env.bind('searchSingle', defineFunction(wrappers.searchSingle, '<s-o?o?:o>'));
     env.bind('resolve', defineFunction(wrappers.resolve, '<s-o?o?:o>'));
     env.bind('literal', defineFunction(wrappers.literal, '<s-o?o?:s>'));
+    env.bind('fhirConnectionNames', defineFunction(function() {
+      return getNamedFhirConnectionNames(this.environment);
+    }, '<:a<s>>'));
     env.bind('useFhirServer', defineFunction(function(target, config) {
       const currentFhirServerSymbol = Symbol.for('fumifier.__currentFhirServer');
 
@@ -2554,6 +2570,8 @@ var fumifier = (function() {
     var logger = options && options.logger;
     var fhirClient = options && options.fhirClient;
     var connectionResolver = options && options.connectionResolver;
+    var hasNamedFhirConnectionNames = options && Object.prototype.hasOwnProperty.call(options, 'namedFhirConnectionNames');
+    var namedFhirConnectionNames = hasNamedFhirConnectionNames ? options.namedFhirConnectionNames : undefined;
     var bindings = options && options.bindings;
     var compiledFhirRegex = {};
 
@@ -2631,6 +2649,9 @@ var fumifier = (function() {
     }
     if (connectionResolver) {
       environment.bind(Symbol.for('fumifier.__connectionResolver'), connectionResolver);
+    }
+    if (hasNamedFhirConnectionNames) {
+      environment.bind(Symbol.for('fumifier.__namedFhirConnectionNames'), namedFhirConnectionNames);
     }
     // Always bind FHIR client wrapper functions (they check for client internally)
     bindFhirClientFunctions(environment);
@@ -2734,6 +2755,9 @@ var fumifier = (function() {
             if (runtimeOptions.connectionResolver) {
               exec_env.bind(Symbol.for('fumifier.__connectionResolver'), runtimeOptions.connectionResolver);
             }
+            if (Object.prototype.hasOwnProperty.call(runtimeOptions, 'namedFhirConnectionNames')) {
+              exec_env.bind(Symbol.for('fumifier.__namedFhirConnectionNames'), runtimeOptions.namedFhirConnectionNames);
+            }
           }
 
           // fresh diagnostics bag per call
@@ -2776,6 +2800,9 @@ var fumifier = (function() {
           }
           if (runtimeOptions.connectionResolver) {
             exec_env.bind(Symbol.for('fumifier.__connectionResolver'), runtimeOptions.connectionResolver);
+          }
+          if (Object.prototype.hasOwnProperty.call(runtimeOptions, 'namedFhirConnectionNames')) {
+            exec_env.bind(Symbol.for('fumifier.__namedFhirConnectionNames'), runtimeOptions.namedFhirConnectionNames);
           }
         }
 

--- a/test/fhir-connection-names.test.js
+++ b/test/fhir-connection-names.test.js
@@ -1,0 +1,63 @@
+import fumifier from '../dist/index.mjs';
+import * as chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+
+const { expect, use } = chai;
+use(chaiAsPromised);
+
+describe('$fhirConnectionNames', function() {
+  it('returns an empty array when no names are configured', async function() {
+    const expr = await fumifier('$fhirConnectionNames()');
+
+    const result = await expr.evaluate({});
+    expect(result).to.deep.equal([]);
+  });
+
+  it('returns configured names in order', async function() {
+    const expr = await fumifier('$fhirConnectionNames()', {
+      namedFhirConnectionNames: ['serverA', 'serverB']
+    });
+
+    const result = await expr.evaluate({});
+    expect(result).to.deep.equal(['serverA', 'serverB']);
+  });
+
+  it('returns a fresh array for each evaluation result', async function() {
+    const expr = await fumifier('$fhirConnectionNames()', {
+      namedFhirConnectionNames: ['serverA', 'serverB']
+    });
+
+    const first = await expr.evaluate({});
+    first.push('mutated');
+
+    const second = await expr.evaluate({});
+    expect(second).to.deep.equal(['serverA', 'serverB']);
+  });
+
+  it('supports runtime overrides', async function() {
+    const expr = await fumifier('$fhirConnectionNames()', {
+      namedFhirConnectionNames: ['compiledA']
+    });
+
+    const result = await expr.evaluate({}, {}, {
+      namedFhirConnectionNames: ['runtimeA', 'runtimeB']
+    });
+
+    expect(result).to.deep.equal(['runtimeA', 'runtimeB']);
+  });
+
+  it('supports provider functions', async function() {
+    const expr = await fumifier('$fhirConnectionNames()', {
+      namedFhirConnectionNames: () => ['serverA', 'serverB']
+    });
+
+    const result = await expr.evaluate({});
+    expect(result).to.deep.equal(['serverA', 'serverB']);
+  });
+
+  it('rejects unexpected arguments through signature validation', async function() {
+    const expr = await fumifier("$fhirConnectionNames('serverA')");
+
+    await expect(expr.evaluate({})).to.be.rejected;
+  });
+});


### PR DESCRIPTION
This pull request introduces support for retrieving the names of configured FHIR server connections within the Fumifier engine, along with comprehensive tests for the new feature. The main addition is the `$fhirConnectionNames()` function, which exposes the list of named FHIR connections (or a provider function) to transformation logic, and allows both compile-time and runtime configuration or override.

**New FHIR connection names support:**

* Added a new `namedFhirConnectionNames` option (array or function) to Fumifier's configuration and evaluation runtime options, allowing users to specify or override named FHIR server connections. [[1]](diffhunk://#diff-37258522e00779c1dad11792df68616b4b0d132fd2cee280baa1e810869ad65aR162-R163) [[2]](diffhunk://#diff-37258522e00779c1dad11792df68616b4b0d132fd2cee280baa1e810869ad65aR173-R174) [[3]](diffhunk://#diff-37258522e00779c1dad11792df68616b4b0d132fd2cee280baa1e810869ad65aR2573-R2574) [[4]](diffhunk://#diff-37258522e00779c1dad11792df68616b4b0d132fd2cee280baa1e810869ad65aR2653-R2655) [[5]](diffhunk://#diff-37258522e00779c1dad11792df68616b4b0d132fd2cee280baa1e810869ad65aR2758-R2760) [[6]](diffhunk://#diff-37258522e00779c1dad11792df68616b4b0d132fd2cee280baa1e810869ad65aR2804-R2806)
* Introduced the `$fhirConnectionNames()` function, accessible from transformation logic, which returns a fresh array of the configured connection names for each evaluation. [[1]](diffhunk://#diff-37258522e00779c1dad11792df68616b4b0d132fd2cee280baa1e810869ad65aR2459-R2467) [[2]](diffhunk://#diff-37258522e00779c1dad11792df68616b4b0d132fd2cee280baa1e810869ad65aR2494-R2496)

**Testing:**

* Added a new test suite (`test/fhir-connection-names.test.js`) to verify correct behavior of `$fhirConnectionNames()`, including empty/default cases, order preservation, runtime overrides, provider function support, and signature validation.

**Other:**

* Bumped the package version to `2.3.0` to reflect the new feature addition.