### PR TITLE
Fix/flash inline wildcard

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -102,6 +102,7 @@ export default [
     languageOptions: sharedLanguageOptions,
     rules: {
       ...sharedRules,
+      'jsdoc/require-jsdoc': 'off',
       'strict': ['error', 'global'], // Override: global instead of function
     },
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,13 @@
       "version": "2.3.0",
       "license": "AGPL-3.0",
       "dependencies": {
-        "lru-cache": "^11.3.5"
+        "lru-cache": "^11.3.6"
       },
       "devDependencies": {
         "@outburn/structure-navigator": "^1.9.5",
-        "@outburn/types": "^0.1.0",
+        "@outburn/types": "^0.2.0",
         "@types/json5": "^0.0.30",
-        "@types/node": "^25.6.0",
+        "@types/node": "^25.8.0",
         "@types/range-parser": "^1.2.7",
         "@types/yargs-parser": "^21.0.3",
         "c8": "^10.1.3",
@@ -23,12 +23,12 @@
         "chai-as-promised": "^8.0.2",
         "eslint": "9.39.2",
         "eslint-plugin-jsdoc": "^62.9.0",
-        "eslint-plugin-promise": "^7.2.1",
-        "fhir-package-explorer": "^1.9.3",
+        "eslint-plugin-promise": "^7.3.0",
+        "fhir-package-explorer": "^1.9.4",
         "fhir-snapshot-generator": "^2.3.1",
         "fhir-terminology-runtime": "^1.3.0",
         "fsh-sushi": "^3.19.0",
-        "globals": "^17.5.0",
+        "globals": "^17.6.0",
         "mocha": "^11.7.5",
         "mocha-lcov-reporter": "^1.3.0",
         "node-fetch": "^3.3.2",
@@ -36,7 +36,7 @@
         "serve": "^14.2.6",
         "tsup": "^8.5.1",
         "typescript": "^5.9.3",
-        "yaml": "^2.8.3"
+        "yaml": "^2.9.0"
       },
       "engines": {
         "node": "20 || >=22"
@@ -45,7 +45,7 @@
         "@outburn/fhir-client": "^1.5.0",
         "@outburn/structure-navigator": "^1.9.5",
         "@outburn/types": "^0.1.0 || ^0.2.0",
-        "fhir-package-explorer": "^1.9.3",
+        "fhir-package-explorer": "^1.9.4",
         "fhir-snapshot-generator": "^2.3.1",
         "fhir-terminology-runtime": "^1.3.0"
       },
@@ -881,9 +881,9 @@
       }
     },
     "node_modules/@outburn/types": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@outburn/types/-/types-0.1.0.tgz",
-      "integrity": "sha512-sOy8CM3tFI7UzMCG5EBwR8pOtWbW0oBlOgNBLnFz3JHVn1mKvwMaEN+1aNqAD90yTrSdac8eHiVfYv4NiCFRNg==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@outburn/types/-/types-0.2.0.tgz",
+      "integrity": "sha512-g0r3IgmmTZLvQ54KmCykVwLaCEWU+rVgX0Polv9cTQolJ/Ve4l9ugCOc90wPErSnHdu0xnxN5swFWGaSe5RWvg==",
       "dev": true,
       "license": "MIT"
     },
@@ -899,9 +899,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
-      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
+      "integrity": "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==",
       "cpu": [
         "arm"
       ],
@@ -913,9 +913,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
-      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz",
+      "integrity": "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==",
       "cpu": [
         "arm64"
       ],
@@ -927,9 +927,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
-      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
+      "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
       "cpu": [
         "arm64"
       ],
@@ -941,9 +941,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
-      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz",
+      "integrity": "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==",
       "cpu": [
         "x64"
       ],
@@ -955,9 +955,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
-      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz",
+      "integrity": "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==",
       "cpu": [
         "arm64"
       ],
@@ -969,9 +969,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
-      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz",
+      "integrity": "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==",
       "cpu": [
         "x64"
       ],
@@ -983,9 +983,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
-      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz",
+      "integrity": "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==",
       "cpu": [
         "arm"
       ],
@@ -1000,9 +1000,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
-      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz",
+      "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
       "cpu": [
         "arm"
       ],
@@ -1017,9 +1017,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
-      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz",
+      "integrity": "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==",
       "cpu": [
         "arm64"
       ],
@@ -1034,9 +1034,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
-      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz",
+      "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
       "cpu": [
         "arm64"
       ],
@@ -1051,9 +1051,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
-      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
+      "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
       "cpu": [
         "loong64"
       ],
@@ -1068,9 +1068,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
-      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
+      "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
       "cpu": [
         "loong64"
       ],
@@ -1085,9 +1085,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
-      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
+      "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
       "cpu": [
         "ppc64"
       ],
@@ -1102,9 +1102,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
-      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
+      "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
       "cpu": [
         "ppc64"
       ],
@@ -1119,9 +1119,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
-      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
+      "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
       "cpu": [
         "riscv64"
       ],
@@ -1136,9 +1136,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
-      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
+      "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
       "cpu": [
         "riscv64"
       ],
@@ -1153,9 +1153,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
-      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz",
+      "integrity": "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==",
       "cpu": [
         "s390x"
       ],
@@ -1170,9 +1170,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
-      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
       "cpu": [
         "x64"
       ],
@@ -1187,9 +1187,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
-      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz",
+      "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
       "cpu": [
         "x64"
       ],
@@ -1204,9 +1204,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
-      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz",
+      "integrity": "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==",
       "cpu": [
         "x64"
       ],
@@ -1218,9 +1218,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
-      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz",
+      "integrity": "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==",
       "cpu": [
         "arm64"
       ],
@@ -1232,9 +1232,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
-      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz",
+      "integrity": "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==",
       "cpu": [
         "arm64"
       ],
@@ -1246,9 +1246,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
-      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz",
+      "integrity": "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==",
       "cpu": [
         "ia32"
       ],
@@ -1260,9 +1260,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
-      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==",
       "cpu": [
         "x64"
       ],
@@ -1274,9 +1274,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
-      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
+      "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
       "cpu": [
         "x64"
       ],
@@ -1312,9 +1312,9 @@
       }
     },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
     },
@@ -1340,13 +1340,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.6.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
-      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "version": "25.8.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.8.0.tgz",
+      "integrity": "sha512-TCFSk8IZh+iLX1xtksoBVtdmgL+1IX0fC9BeU4QqFSuNdN/K+HUlhqOzEmSYYpZUVsLYcPqc9KX+60iDuninSQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.19.0"
+        "undici-types": ">=7.24.0 <7.24.7"
       }
     },
     "node_modules/@types/range-parser": {
@@ -1371,9 +1371,9 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.59.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.0.tgz",
-      "integrity": "sha512-nLzdsT1gdOgFxxxwrlNVUBzSNBEEHJ86bblmk4QAS6stfig7rcJzWKqCyxFy3YRRHXDWEkb2NralA1nOYkkm/A==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.3.tgz",
+      "integrity": "sha512-ePFoH0g4ludssdRFqqDxQePCxU4WQyRa9+XVwjm7yLn0FKhMeoetC+qBEEI1Eyb1pGSDveTIT09Bvw2WhlGayg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1602,21 +1602,49 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
-      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
     },
+    "node_modules/axios/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/axios/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/b4a": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.0.tgz",
-      "integrity": "sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
       "dev": true,
       "license": "Apache-2.0",
       "peerDependencies": {
@@ -1636,9 +1664,9 @@
       "license": "MIT"
     },
     "node_modules/bare-events": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
-      "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.3.tgz",
+      "integrity": "sha512-HdUm8EMQBLaJvGUdidNNbqpA1kYkwNcb+MYxkxCLAPJGQzlv9J0C24h8V65Z4c5GLd/JEALDvpFCQgpLJqc0zw==",
       "dev": true,
       "license": "Apache-2.0",
       "peerDependencies": {
@@ -1676,9 +1704,9 @@
       }
     },
     "node_modules/bare-os": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.0.tgz",
-      "integrity": "sha512-JTjuZyNIDpw+GytMO4a6TK1VXdVKKJr6DRxEHasyuYyShV2deuiHJK/ahGZlebc+SG0/wJCB9XK8gprBGDFi/Q==",
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.1.tgz",
+      "integrity": "sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -1696,9 +1724,9 @@
       }
     },
     "node_modules/bare-stream": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.0.tgz",
-      "integrity": "sha512-3zAJRZMDFGjdn+RVnNpF9kuELw+0Fl3lpndM4NcEOhb9zwtSo/deETfuIwMSE5BXanA0FrN1qVjffGwAg2Y7EA==",
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.1.tgz",
+      "integrity": "sha512-Vp0cnjYyrEC4whYTymQ+YZi6pBpfiICZO3cfRG8sy67ZNWe951urv1x4eW1BKNngw3U+3fPYb5JQvHbCtxH7Ow==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1723,9 +1751,9 @@
       }
     },
     "node_modules/bare-url": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.2.tgz",
-      "integrity": "sha512-/9a2j4ac6ckpmAHvod/ob7x439OAHst/drc2Clnq+reRYd/ovddwcF4LfoxHyNk5AuGBnPg+HqFjmE/Zpq6v0A==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.3.tgz",
+      "integrity": "sha512-Kccpc7ACfXaxfeInfqKcZtW4pT5YBn1mesc4sCsun6sRwtbJ4h+sNOaksUpYEJUKfN65YWC6Bw2OJEFiKxq8nQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2703,9 +2731,9 @@
       }
     },
     "node_modules/eslint-plugin-promise": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-7.2.1.tgz",
-      "integrity": "sha512-SWKjd+EuvWkYaS+uN2csvj0KoP43YTu7+phKQ5v+xw6+A0gutVX2yqCeCkC3uLCJFiPfR2dD8Es5L7yUsmvEaA==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-7.3.0.tgz",
+      "integrity": "sha512-6uGiOR0INuujr6PEQmeSSP7GbIMJ/ebEXXiEzb/nOj68LknH5Pxzb/AbZivmr6VE6TkTE8rTjRK9zhKpK6HsRA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -2718,7 +2746,7 @@
         "url": "https://opencollective.com/eslint"
       },
       "peerDependencies": {
-        "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0"
+        "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0"
       }
     },
     "node_modules/eslint-scope": {
@@ -2885,9 +2913,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {
@@ -2951,28 +2979,28 @@
       }
     },
     "node_modules/fhir-package-explorer": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/fhir-package-explorer/-/fhir-package-explorer-1.9.3.tgz",
-      "integrity": "sha512-3i02y8fkVJI5NZQy89udC8CKJPpClV7H8hehEyNWxTVcq0Y7S0ilYjrzik95YEBApkxZf1AN9vpyM6PpaO3lDA==",
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/fhir-package-explorer/-/fhir-package-explorer-1.9.4.tgz",
+      "integrity": "sha512-nnEfCYzZ1aOUQ6V4xhJbBMveVf4eN3nQs3rmcF7DMod3/OsXc0yI/hFd9IeGqrKeVQMWduDGz1FhwLAe+34alQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "fhir-package-installer": "^1.12.0",
-        "fs-extra": "^11.3.4",
-        "lru-cache": "^11.2.7"
+        "fhir-package-installer": "^1.13.0",
+        "fs-extra": "^11.3.5",
+        "lru-cache": "^11.3.6"
       }
     },
     "node_modules/fhir-package-installer": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/fhir-package-installer/-/fhir-package-installer-1.12.0.tgz",
-      "integrity": "sha512-Z91iTa11+Qqg39fsxmjRL+2mN47/bOWz+9NKHQF21slLGORbR5XAF70EO16aqsr4gXJVOxdlWUeYFFAnZyU5Dg==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/fhir-package-installer/-/fhir-package-installer-1.13.0.tgz",
+      "integrity": "sha512-a5QTbpXh9CQErF+apXG8oXKxzWsjlhPOvRKJucELi8ylRnIJ9QaZWnONFT9YbXsv61U2l6DV3sTCNKParzQW/g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "fs-extra": "^11.3.4",
+        "fs-extra": "^11.3.5",
         "p-limit": "^7.3.0",
-        "semver": "^7.7.4",
-        "tar-stream": "^3.1.8"
+        "semver": "^7.8.0",
+        "tar-stream": "^3.2.0"
       }
     },
     "node_modules/fhir-package-loader": {
@@ -3206,9 +3234,9 @@
       }
     },
     "node_modules/fs-extra": {
-      "version": "11.3.4",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
-      "integrity": "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==",
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
+      "integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3445,9 +3473,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "17.5.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.5.0.tgz",
-      "integrity": "sha512-qoV+HK2yFl/366t2/Cb3+xxPUo5BuMynomoDmiaZBIdbs+0pYbjfZU+twLhGKp4uCZ/+NbtpVepH5bGCxRyy2g==",
+      "version": "17.6.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.6.0.tgz",
+      "integrity": "sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4082,9 +4110,9 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "11.3.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
-      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "version": "11.3.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
+      "integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -4239,9 +4267,9 @@
       }
     },
     "node_modules/mnemonist": {
-      "version": "0.40.3",
-      "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.40.3.tgz",
-      "integrity": "sha512-Vjyr90sJ23CKKH/qPAgUKicw/v6pRoamxIEDFOF8uSgFME7DqPRpHgRTejWVjkdGg5dXj0/NyxZHZ9bcjH+2uQ==",
+      "version": "0.40.4",
+      "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.40.4.tgz",
+      "integrity": "sha512-ZAv+KNavneRVzu4tUeOgzkScI3W5BGwZ3rkxIpKtzzVgfTtWQFN1CgX0U72cyvyh3iTuHL3SiSmrQxTlryEIcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5035,9 +5063,9 @@
       }
     },
     "node_modules/rimraf/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5099,9 +5127,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
-      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
+      "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5115,33 +5143,40 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.60.2",
-        "@rollup/rollup-android-arm64": "4.60.2",
-        "@rollup/rollup-darwin-arm64": "4.60.2",
-        "@rollup/rollup-darwin-x64": "4.60.2",
-        "@rollup/rollup-freebsd-arm64": "4.60.2",
-        "@rollup/rollup-freebsd-x64": "4.60.2",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
-        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
-        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
-        "@rollup/rollup-linux-arm64-musl": "4.60.2",
-        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
-        "@rollup/rollup-linux-loong64-musl": "4.60.2",
-        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
-        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
-        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
-        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
-        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
-        "@rollup/rollup-linux-x64-gnu": "4.60.2",
-        "@rollup/rollup-linux-x64-musl": "4.60.2",
-        "@rollup/rollup-openbsd-x64": "4.60.2",
-        "@rollup/rollup-openharmony-arm64": "4.60.2",
-        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
-        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
-        "@rollup/rollup-win32-x64-gnu": "4.60.2",
-        "@rollup/rollup-win32-x64-msvc": "4.60.2",
+        "@rollup/rollup-android-arm-eabi": "4.60.4",
+        "@rollup/rollup-android-arm64": "4.60.4",
+        "@rollup/rollup-darwin-arm64": "4.60.4",
+        "@rollup/rollup-darwin-x64": "4.60.4",
+        "@rollup/rollup-freebsd-arm64": "4.60.4",
+        "@rollup/rollup-freebsd-x64": "4.60.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.4",
+        "@rollup/rollup-linux-arm64-musl": "4.60.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.4",
+        "@rollup/rollup-linux-loong64-musl": "4.60.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-musl": "4.60.4",
+        "@rollup/rollup-openbsd-x64": "4.60.4",
+        "@rollup/rollup-openharmony-arm64": "4.60.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.4",
+        "@rollup/rollup-win32-x64-gnu": "4.60.4",
+        "@rollup/rollup-win32-x64-msvc": "4.60.4",
         "fsevents": "~2.3.2"
       }
+    },
+    "node_modules/rollup/node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
@@ -5195,9 +5230,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -5624,9 +5659,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.13",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
-      "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
+      "version": "7.5.15",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.15.tgz",
+      "integrity": "sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -5641,9 +5676,9 @@
       }
     },
     "node_modules/tar-stream": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.8.tgz",
-      "integrity": "sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
+      "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5764,9 +5799,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6048,16 +6083,16 @@
       }
     },
     "node_modules/ufo": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
-      "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+      "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/undici-types": {
-      "version": "7.19.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
-      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
       "dev": true,
       "license": "MIT"
     },
@@ -6357,9 +6392,9 @@
       }
     },
     "node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "dev": true,
       "license": "ISC",
       "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fumifier",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fumifier",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "license": "AGPL-3.0",
       "dependencies": {
         "lru-cache": "^11.3.6"

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "LICENSES/**"
   ],
   "dependencies": {
-    "lru-cache": "^11.3.5"
+    "lru-cache": "^11.3.6"
   },
   "devDependencies": {
     "@outburn/structure-navigator": "^1.9.5",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "eslint": "9.39.2",
     "eslint-plugin-jsdoc": "^62.9.0",
     "eslint-plugin-promise": "^7.3.0",
-    "fhir-package-explorer": "^1.9.3",
+    "fhir-package-explorer": "^1.9.4",
     "fhir-snapshot-generator": "^2.3.1",
     "fhir-terminology-runtime": "^1.3.0",
     "fsh-sushi": "^3.19.0",
@@ -125,7 +125,7 @@
     "@outburn/fhir-client": "^1.5.0",
     "@outburn/structure-navigator": "^1.9.5",
     "@outburn/types": "^0.1.0 || ^0.2.0",
-    "fhir-package-explorer": "^1.9.3",
+    "fhir-package-explorer": "^1.9.4",
     "fhir-snapshot-generator": "^2.3.1",
     "fhir-terminology-runtime": "^1.3.0"
   },

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "pretest": "npm run build:for-tests",
     "mocha": "c8 mocha test/**/*.test.js --timeout=20000",
     "test": "npm run mocha",
+    "test:coldstart": "rimraf test/.test-cache && npm run test",
     "test:flash": "npm run build:for-tests && c8 mocha test/run-test-suite.test.js --timeout=20000 -- --flash-only",
     "test:policy": "npm run build:for-tests && c8 mocha test/verbose-policy.test.js --timeout=20000",
     "check-coverage": "c8 check-coverage --statements 94 --branches 90 --functions 94 --lines 94",

--- a/package.json
+++ b/package.json
@@ -93,9 +93,9 @@
   },
   "devDependencies": {
     "@outburn/structure-navigator": "^1.9.5",
-    "@outburn/types": "^0.1.0",
+    "@outburn/types": "^0.2.0",
     "@types/json5": "^0.0.30",
-    "@types/node": "^25.6.0",
+    "@types/node": "^25.8.0",
     "@types/range-parser": "^1.2.7",
     "@types/yargs-parser": "^21.0.3",
     "c8": "^10.1.3",
@@ -103,12 +103,12 @@
     "chai-as-promised": "^8.0.2",
     "eslint": "9.39.2",
     "eslint-plugin-jsdoc": "^62.9.0",
-    "eslint-plugin-promise": "^7.2.1",
+    "eslint-plugin-promise": "^7.3.0",
     "fhir-package-explorer": "^1.9.3",
     "fhir-snapshot-generator": "^2.3.1",
     "fhir-terminology-runtime": "^1.3.0",
     "fsh-sushi": "^3.19.0",
-    "globals": "^17.5.0",
+    "globals": "^17.6.0",
     "mocha": "^11.7.5",
     "mocha-lcov-reporter": "^1.3.0",
     "node-fetch": "^3.3.2",
@@ -116,7 +116,7 @@
     "serve": "^14.2.6",
     "tsup": "^8.5.1",
     "typescript": "^5.9.3",
-    "yaml": "^2.8.3"
+    "yaml": "^2.9.0"
   },
   "engines": {
     "node": "20 || >=22"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fumifier",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Fumifier is the core FLASH DSL engine inside FUME - It parses, compiles and executes FHIR related transformation logic expressed with FUME's specialized syntax (FLASH) and applies it to JSON data structures.",
   "author": "Outburn Ltd.",
   "main": "./dist/index.cjs",

--- a/src/cjs/browser.js
+++ b/src/cjs/browser.js
@@ -1,0 +1,3 @@
+import browserApi from '../browser.js';
+
+export default browserApi;

--- a/src/cjs/index.js
+++ b/src/cjs/index.js
@@ -1,0 +1,5 @@
+import fumifier, { FumifierError } from '../fumifier.js';
+
+fumifier.FumifierError = FumifierError;
+
+export default fumifier;

--- a/src/parser.js
+++ b/src/parser.js
@@ -586,6 +586,21 @@ const parser = (() => {
           }
         }
         var rule = expression(0, true);
+        if (recover && (rule.type === '(error)' || rule.type === 'error')) {
+          rules.push({
+            type: 'error',
+            error: rule.error || rule,
+            position: rule.position,
+            start: rule.start,
+            line: rule.line
+          });
+          if (node.id === ';') advance();
+          if (node.id !== "(indent)" || node.value !== level) {
+            break;
+          }
+          advance("(indent)");
+          continue;
+        }
         // ensure expression is either a flashrule or a bind rule
         if (rule.type !== 'flashrule' && rule.id !== ':=') {
           if (rule.id === '=') {
@@ -811,6 +826,9 @@ const parser = (() => {
           advance(".", true);
         }
         this.path = parseFlashPath();
+        if (recover && (this.path.type === '(error)' || this.path.type === 'error')) {
+          return this.path;
+        }
         if (node.id === '=') {
           advance('=');
           if (node.id !== '(end)' && node.id !== '(indent)') {

--- a/src/parser.js
+++ b/src/parser.js
@@ -588,12 +588,13 @@ const parser = (() => {
         }
         var rule = expression(0, true);
         if (recover && (rule.type === '(error)' || rule.type === 'error')) {
+          var err = rule.error || rule;
           rules.push({
             type: 'error',
-            error: rule.error || rule,
-            position: rule.position,
-            start: rule.start,
-            line: rule.line
+            error: err,
+            position: err.position,
+            start: err.start,
+            line: err.line
           });
           if (node.id === ';') advance();
           if (node.id !== "(indent)" || node.value !== level) {

--- a/src/parser.js
+++ b/src/parser.js
@@ -49,6 +49,7 @@ const parser = (() => {
      * When off, indent tokens are ignored entirely and regular JSONata mode is used where indents are not significant.
      */
     var indentAwareMode = false;
+    var parsingFlashInlineExpression = false;
 
     /**
      * Every token, such as an operator or identifier, will inherit from a symbol.
@@ -812,6 +813,10 @@ const parser = (() => {
     // field wildcard (single level) OR flash rule
     prefix('*', function () {
       var { position, line, start } = this;
+      if (indentAwareMode && parsingFlashInlineExpression) {
+        this.type = 'wildcard';
+        return this;
+      }
       if (indentAwareMode) {
         // a flash rule node will have:
         // - type: 'flashrule'
@@ -832,7 +837,12 @@ const parser = (() => {
         if (node.id === '=') {
           advance('=');
           if (node.id !== '(end)' && node.id !== '(indent)') {
-            this.inlineExpression = expression(0);
+            parsingFlashInlineExpression = true;
+            try {
+              this.inlineExpression = expression(0);
+            } finally {
+              parsingFlashInlineExpression = false;
+            }
             // Allow optional trailing semicolon after inline expression for backwards compatibility
             if (node.id === ';') {
               var semicolonLine = node.line;

--- a/src/utils/preProcessAst.js
+++ b/src/utils/preProcessAst.js
@@ -78,6 +78,17 @@ function processFlashBlock(node) {
  *    has an inline expression and/or sub-rules → becomes an array of expressions
  */
 function processFlashRule(node) {
+  if (node.path?.type === '(error)' || node.path?.type === 'error') {
+    const error = node.path.error || node.path;
+    return {
+      type: 'error',
+      error,
+      position: error.position,
+      start: error.start,
+      line: error.line
+    };
+  }
+
   const result = { ...node };
   result.type = 'unary';
   result.value = '[';

--- a/test/ast-mobility.test.js
+++ b/test/ast-mobility.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable require-jsdoc */
 import fumifier from '../src/fumifier.js';
 import assert from 'assert';
 import { FhirStructureNavigator } from "@outburn/structure-navigator";
@@ -11,7 +10,7 @@ describe('AST Mobility Feature', function() {
   let terminologyRuntime;
 
   before(async function() {
-    this.timeout(180000); // Set timeout to 180 seconds (3 minutes)
+    this.timeout(720000); // Set timeout to 720 seconds (12 minutes)
 
     // Create shared FhirPackageExplorer instance
     const fpe = await FhirPackageExplorer.create({
@@ -27,7 +26,8 @@ describe('AST Mobility Feature', function() {
 
     // Create FhirTerminologyRuntime with shared FPE
     terminologyRuntime = await FhirTerminologyRuntime.create({ fpe });
-  });
+  }, 720000); // 12 minutes
+
   it('should create fumifier object from AST JSON', async function() {
     // Create original expression
     const originalExpr = await fumifier('1 + 2');

--- a/test/ast-mobility.test.js
+++ b/test/ast-mobility.test.js
@@ -26,7 +26,7 @@ describe('AST Mobility Feature', function() {
 
     // Create FhirTerminologyRuntime with shared FPE
     terminologyRuntime = await FhirTerminologyRuntime.create({ fpe });
-  }, 720000); // 12 minutes
+  });
 
   it('should create fumifier object from AST JSON', async function() {
     // Create original expression

--- a/test/ast-resolution-optimization.test.js
+++ b/test/ast-resolution-optimization.test.js
@@ -10,7 +10,7 @@ describe('AST Resolution Optimization', function() {
   let terminologyRuntime;
 
   before(async function() {
-    this.timeout(180000); // Set timeout to 180 seconds (3 minutes)
+    this.timeout(720000); // Set timeout to 720 seconds (12 minutes)
 
     // Create shared FhirPackageExplorer instance
     const fpe = await FhirPackageExplorer.create({

--- a/test/browser-entry.test.js
+++ b/test/browser-entry.test.js
@@ -9,11 +9,13 @@ import assert from 'assert';
 describe('Browser Entry Point', function() {
   let browserModuleEsm;
   let browserModuleCjs;
+  let mainModuleCjs;
 
   before(async function() {
     // Load both ES Module and CommonJS versions
     const require = createRequire(import.meta.url);
     browserModuleCjs = require('../dist/browser.cjs');
+    mainModuleCjs = require('../dist/index.cjs');
     browserModuleEsm = await import('../dist/browser.mjs');
   });
 
@@ -35,6 +37,20 @@ describe('Browser Entry Point', function() {
       assert(typeof cjsApi.parse === 'function', 'CommonJS should have parse function');
       assert(typeof cjsApi.validate === 'function', 'CommonJS should have validate function');
       assert(typeof cjsApi.tokenize === 'function', 'CommonJS should have tokenize function');
+    });
+
+    it('should expose parsing functions as named properties from the CommonJS browser bundle', function() {
+      assert.equal(typeof browserModuleCjs.parse, 'function', 'CommonJS browser bundle should expose parse');
+      assert.equal(typeof browserModuleCjs.validate, 'function', 'CommonJS browser bundle should expose validate');
+      assert.equal(typeof browserModuleCjs.tokenize, 'function', 'CommonJS browser bundle should expose tokenize');
+    });
+
+    it('should expose FumifierError from the CommonJS main bundle', function() {
+      assert.equal(typeof mainModuleCjs, 'function', 'CommonJS main bundle should expose the fumifier function');
+      assert.equal(typeof mainModuleCjs.FumifierError, 'function',
+        'CommonJS main bundle should expose the FumifierError constructor');
+      assert(Object.prototype.hasOwnProperty.call(mainModuleCjs, 'FumifierError'),
+        'CommonJS main bundle should expose FumifierError as an own property');
     });
   });
 

--- a/test/cached-parsing.test.js
+++ b/test/cached-parsing.test.js
@@ -13,7 +13,7 @@ describe('Cached Parsing Feature', function() {
   let terminologyRuntime;
 
   before(async function() {
-    this.timeout(180000); // Set timeout to 180 seconds (3 minutes)
+    this.timeout(720000); // Set timeout to 720 seconds (12 minutes)
 
     // Create shared FhirPackageExplorer instance
     const fpe = await FhirPackageExplorer.create({

--- a/test/flash-parser-hardening.test.js
+++ b/test/flash-parser-hardening.test.js
@@ -86,6 +86,19 @@ describe('FLASH parser hardening regression', function() {
     assert.equal(ast.errors, undefined);
   });
 
+  it('should preserve error locations for malformed FLASH rules in recover=true mode', function() {
+    const ast = parse(malformedDoubleStarExpression, true);
+    const malformedWildcardStart = malformedDoubleStarExpression.lastIndexOf('*');
+
+    assert(ast, 'Expected recover=true parsing to return an AST');
+    assert(Array.isArray(ast.errors), 'Expected malformed recover-mode parse to attach errors');
+    assert.equal(ast.errors.length, 1, 'Expected a single malformed rule error');
+    assert.equal(ast.errors[0].code, 'F1022');
+    assert.equal(ast.errors[0].line, 3);
+    assert.equal(ast.errors[0].position, malformedWildcardStart + 1);
+    assert.equal(ast.errors[0].start, malformedWildcardStart);
+  });
+
   it('should validate the unwrapped expression as valid', function() {
     const result = validate(issueExpression);
 

--- a/test/flash-parser-hardening.test.js
+++ b/test/flash-parser-hardening.test.js
@@ -1,0 +1,131 @@
+import assert from 'assert';
+import { parse, validate } from '../dist/browser.mjs';
+import fumifier from '../dist/index.mjs';
+import { FhirStructureNavigator } from '@outburn/structure-navigator';
+import { FhirSnapshotGenerator } from 'fhir-snapshot-generator';
+import { FhirTerminologyRuntime } from 'fhir-terminology-runtime';
+import { FhirPackageExplorer } from 'fhir-package-explorer';
+
+const issueExpression = `InstanceOf: Patient
+* address
+  * ($uuid('1')).line = $
+    * ({'k': $}).extension[http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-streetName]
+      * valueString = *`;
+
+const parenthesizedControlExpression = `InstanceOf: Patient
+* address
+  * ($uuid('1')).line = $
+    * ({'k': $}).extension[http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-streetName]
+      * valueString = (*)`;
+
+const malformedDoubleStarExpression = `InstanceOf: Patient
+* address
+  * * valueString = 'x'`;
+
+function findInlineWildcards(node, found = []) {
+  if (!node || typeof node !== 'object') {
+    return found;
+  }
+
+  if (node.isInlineExpression && node.type === 'wildcard') {
+    found.push(node);
+  }
+
+  for (const value of Object.values(node)) {
+    if (Array.isArray(value)) {
+      value.forEach(item => findInlineWildcards(item, found));
+    } else {
+      findInlineWildcards(value, found);
+    }
+  }
+
+  return found;
+}
+
+describe('FLASH parser hardening regression', function() {
+  let navigator;
+  let terminologyRuntime;
+
+  before(async function() {
+    this.timeout(720000);
+
+    const fpe = await FhirPackageExplorer.create({
+      context: ['il.core.fhir.r4#0.17.0', 'fumifier.test.pkg#0.1.0'],
+      cachePath: './test/.test-cache',
+      fhirVersion: '4.0.1',
+      cacheMode: 'lazy'
+    });
+
+    const fsg = await FhirSnapshotGenerator.create({ fpe, fhirVersion: '4.0.1', cacheMode: 'lazy' });
+    navigator = new FhirStructureNavigator(fsg);
+    terminologyRuntime = await FhirTerminologyRuntime.create({ fpe });
+  });
+
+  it('should parse bare wildcard inline assignments successfully when recover=false', function() {
+    const ast = parse(issueExpression, false);
+
+    assert(ast, 'Expected the unwrapped inline wildcard expression to parse');
+    assert.equal(ast.containsFlash, true, 'Expected FLASH syntax to be detected');
+    assert.equal(ast.errors, undefined);
+  });
+
+  it('should produce an inline wildcard node for the bare RHS *', function() {
+    const ast = parse(issueExpression, false);
+    const inlineWildcards = findInlineWildcards(ast);
+
+    assert.equal(inlineWildcards.length, 1, 'Expected one inline wildcard node in the parsed AST');
+    assert.equal(inlineWildcards[0].line, 5);
+    assert.equal(typeof inlineWildcards[0].position, 'number');
+    assert(inlineWildcards[0].position >= issueExpression.indexOf('* valueString = *'));
+  });
+
+  it('should also parse successfully in recover=true mode without attaching errors', function() {
+    const ast = parse(issueExpression, true);
+
+    assert(ast, 'Expected recover=true parsing to return an AST');
+    assert.equal(ast.errors, undefined);
+  });
+
+  it('should validate the unwrapped expression as valid', function() {
+    const result = validate(issueExpression);
+
+    assert.equal(result.isValid, true);
+    assert(Array.isArray(result.errors), 'Expected validate() to return an errors array');
+    assert.equal(result.errors.length, 0);
+  });
+
+  it('should still reject malformed double-star FLASH rules with F1022', function() {
+    assert.throws(
+      () => parse(malformedDoubleStarExpression, false),
+      (error) => {
+        assert.equal(error.code, 'F1022');
+        assert.equal(error.line, 3);
+        return true;
+      }
+    );
+  });
+
+  it('should still parse the parenthesized wildcard workaround', function() {
+    const ast = parse(parenthesizedControlExpression, false);
+
+    assert(ast, 'Expected the parenthesized control expression to parse');
+    assert.equal(ast.containsFlash, true, 'Expected FLASH syntax to be detected');
+  });
+
+  it('should evaluate the unwrapped and parenthesized expressions to the same Patient output', async function() {
+    const unwrapped = await fumifier(issueExpression, { navigator, terminologyRuntime });
+    const wrapped = await fumifier(parenthesizedControlExpression, { navigator, terminologyRuntime });
+
+    const unwrappedResult = await unwrapped.evaluate({});
+    const wrappedResult = await wrapped.evaluate({});
+
+    assert.deepEqual(unwrappedResult, wrappedResult);
+    assert.equal(unwrappedResult.resourceType, 'Patient');
+    assert.equal(unwrappedResult.address[0].line[0], '356a192b-7913-504c-9457-4d18c28d46e6');
+    assert.equal(unwrappedResult.address[0]._line[0].extension[0].url, 'http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-streetName');
+    assert.equal(
+      unwrappedResult.address[0]._line[0].extension[0].valueString,
+      unwrappedResult.address[0].line[0]
+    );
+  });
+});

--- a/test/mapping-repository-flash.test.js
+++ b/test/mapping-repository-flash.test.js
@@ -11,7 +11,7 @@ describe('Mapping Repository with FLASH Expressions', function() {
   let terminologyRuntime;
 
   before(async function() {
-    this.timeout(180000); // Set timeout to 180 seconds (3 minutes)
+    this.timeout(720000); // Set timeout to 720 seconds (12 minutes)
 
     // Create shared FhirPackageExplorer instance
     const fpe = await FhirPackageExplorer.create({

--- a/test/mapping-repository.test.js
+++ b/test/mapping-repository.test.js
@@ -5,7 +5,7 @@ import assert from 'assert';
 describe('Mapping Repository Feature', function() {
 
   before(async function() {
-    this.timeout(180000); // Set timeout to 180 seconds (3 minutes)
+    this.timeout(720000); // Set timeout to 720 seconds (12 minutes)
   });
 
   describe('Mapping Cache Interface', function() {

--- a/test/parser-recovery.test.js
+++ b/test/parser-recovery.test.js
@@ -1,6 +1,10 @@
 import fumifier from '../dist/index.mjs';
 import assert from 'assert';
-import { expect } from 'chai';
+import * as chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+
+const { expect, use } = chai;
+use(chaiAsPromised);
 
 describe('Invoke parser with valid expression', function() {
   describe('Account.Order[0]', function() {

--- a/test/run-test-suite.test.js
+++ b/test/run-test-suite.test.js
@@ -75,7 +75,7 @@ describe("Fumifier Test Suite", () => {
   var terminologyRuntime;
   var fhirClient;
   before(async function() {
-    this.timeout(180000); // Set timeout to 180 seconds (3 minutes)
+    this.timeout(720000); // Set timeout to 720 seconds (12 minutes)
 
     // Create shared FhirPackageExplorer instance
     const fpe = await FhirPackageExplorer.create({

--- a/tsup.config.js
+++ b/tsup.config.js
@@ -1,24 +1,41 @@
 import { defineConfig } from 'tsup';
 
-export default defineConfig({
-  entry: {
-    index: 'src/fumifier.js',
-    browser: 'src/browser.js'
-  },
-  format: ['cjs', 'esm'],
+const sharedConfig = {
   outDir: 'dist',
   sourcemap: true,
-  clean: true,
   target: 'node20',
   minify: false,
   treeshake: true,
   skipNodeModulesBundle: true,
   splitting: false,
-  outExtension({ format }) {
-    if (format === 'esm') return { js: '.mjs' };
-    return { js: '.cjs' };
-  },
   // Since this is a JS-only package, we don't need dts generation from tsup
   // We'll keep the existing TypeScript-based type generation
   dts: false
-});
+};
+
+export default defineConfig([
+  {
+    ...sharedConfig,
+    entry: {
+      index: 'src/fumifier.js',
+      browser: 'src/browser.js'
+    },
+    format: ['esm'],
+    clean: true,
+    outExtension() {
+      return { js: '.mjs' };
+    },
+  },
+  {
+    ...sharedConfig,
+    entry: {
+      index: 'src/cjs/index.js',
+      browser: 'src/cjs/browser.js'
+    },
+    format: ['cjs'],
+    clean: false,
+    outExtension() {
+      return { js: '.cjs' };
+    },
+  }
+]);


### PR DESCRIPTION
## Summary

Fix FLASH inline wildcard parsing for expressions like `* valueString = *` without changing the existing recover-mode error classification behavior for malformed input.

Resolves #80 

This PR also includes the test, lint, and packaging follow-up needed to validate and ship the fix cleanly.

## What Changed

- Fixed FLASH parsing so a bare `*` on the right-hand side of an inline assignment is interpreted as an inline wildcard only in the correct inline-expression context.
- Preserved recover-mode parser errors through FLASH rule collection and AST preprocessing so malformed FLASH input continues surfacing structured parser errors instead of crashing downstream preprocessing/runtime code.
- Added a focused regression suite covering:
  - successful parsing of the unwrapped inline wildcard form
  - recover-mode behavior
  - validation behavior
  - rejection of malformed double-star FLASH rules
  - runtime equivalence between the unwrapped form and the existing parenthesized workaround
- Restored promise-rejection assertions in the parser recovery tests by wiring `chai-as-promised`.
- Disabled `jsdoc/require-jsdoc` for `test/**/*.js` so test files are not forced to carry JSDoc comments.
- Refactored the build so ESM and CJS bundles use separate entry points, which removes the CommonJS mixed-export warnings while preserving the `require()` API shape.
- Added a `test:coldstart` script, increased several long-running integration test timeouts for slower cold starts, updated dependencies/lockfile, and bumped the package version to `2.3.1`.

## Why

The parser was incorrectly treating the bare `*` in inline FLASH assignments as a rule-level token instead of a valid inline wildcard expression. In recover mode, related malformed input could also survive long enough to cause downstream failures instead of staying represented as structured parser errors.

## Validation

- `npm run build`
- `npm run build:for-tests`
- `node_modules/.bin/mocha test/flash-parser-hardening.test.js test/parser-recovery.test.js test/browser-entry.test.js --timeout=20000`

## Notes

- The parser fix is intentionally narrow: it only changes `*` handling inside inline FLASH expression parsing and keeps existing malformed rule behavior intact.
- The packaging change removes the `named and default exports together` CommonJS build warnings without changing the ESM surface.