### PR TITLE
Parser Slash, Regex, and Recovery Hardening

### DIFF
--- a/release-notes-parser-regex-hardening.md
+++ b/release-notes-parser-regex-hardening.md
@@ -1,0 +1,27 @@
+# Draft Release Notes: Parser and Regex Hardening
+
+This release improves parser recovery, regex handling, and browser-facing token metadata for FLASH/FUME expressions.
+
+## Highlights
+
+- Parser recovery now keeps later division operators as division operators after an earlier syntax error, instead of misreporting them as unterminated regex literals.
+- Missing-right-hand-side errors now point directly at the offending operator for cases like `1/`, `(1/)`, and `$var := ;`.
+- Browser tokenization now returns stable regex token coordinates and explicit regex flags.
+- Exported ASTs now use serializable regex metadata instead of live compiled `RegExp` objects, which improves JSON round-tripping and AST mobility workflows.
+- Regex literals are now compiled once per evaluation context and reused within that evaluation, reducing repeated regex setup in per-item flows such as filters.
+
+## User-Visible Corrections
+
+- Fixed misleading `S0302` regex errors that could appear after unrelated earlier syntax errors.
+- Added a more actionable missing-RHS diagnostic: `S0218`.
+- Stabilized regex node and token coordinates for downstream editor and tooling consumers.
+
+## Notes for Integrators
+
+- Regex entries in exported ASTs and browser token arrays no longer expose live `RegExp` instances.
+- Consumers should read regex metadata from `value` and `flags` instead.
+
+## Validation Summary
+
+- Focused parser/browser/AST validation completed successfully.
+- Broader Mocha regression coverage completed successfully.

--- a/src/browser.js
+++ b/src/browser.js
@@ -253,13 +253,17 @@ export function tokenize(expression) {
     let token = lexer.next(infix);
     while (token !== null) {
       // Convert position (end) to end for consistency
-      tokens.push({
+      const tokenInfo = {
         type: token.type,
         value: token.value,
         start: token.start,
         end: token.position,
         line: token.line || 1
-      });
+      };
+      if (token.type === 'regex' && Object.prototype.hasOwnProperty.call(token, 'flags')) {
+        tokenInfo.flags = token.flags;
+      }
+      tokens.push(tokenInfo);
 
       infix = canStartInfix(token);
       token = lexer.next(infix);

--- a/src/browser.js
+++ b/src/browser.js
@@ -187,7 +187,9 @@ export function validate(expression) {
       type: error.type || 'ParseError'
     };
 
-    populateMessage(fumeError);
+    if (!error.message) {
+      populateMessage(fumeError);
+    }
     return {
       isValid: false,
       errors: [fumeError]

--- a/src/fumifier.js
+++ b/src/fumifier.js
@@ -235,6 +235,7 @@ var fumifier = (function() {
   // Start of Evaluator code
 
   var staticFrame = createFrame(null);
+  const regexEvalCacheSymbol = Symbol.for('fumifier.__regexEvalCache');
 
   /**
      * Evaluate expression against input data
@@ -1363,8 +1364,19 @@ var fumifier = (function() {
      * @param {Object} expr - expression containing regex
      * @returns {Function} Higher order function representing prepared regex
      */
-  function evaluateRegex(expr) {
-    var re = new RegExp(expr.value);
+  function evaluateRegex(expr, input, environment) {
+    var regexCache = environment.lookup(regexEvalCacheSymbol);
+    if (regexCache && regexCache.has(expr)) {
+      return regexCache.get(expr);
+    }
+
+    var pattern = expr.value instanceof RegExp ? expr.value.source : expr.value;
+    var flags = expr.flags || (expr.value instanceof RegExp ? expr.value.flags : 'g');
+    if (flags.indexOf('g') === -1) {
+      flags += 'g';
+    }
+
+    var re = new RegExp(pattern, flags);
     var closure = function(str, fromIndex) {
       var result;
       re.lastIndex = fromIndex || 0;
@@ -1393,7 +1405,7 @@ var fumifier = (function() {
                 stack: (new Error()).stack,
                 position: expr.position,
                 start: expr.start,
-                value: expr.value.source
+                value: pattern
               };
             }
             return next;
@@ -1403,6 +1415,11 @@ var fumifier = (function() {
 
       return result;
     };
+
+    if (regexCache) {
+      regexCache.set(expr, closure);
+    }
+
     return closure;
   }
 
@@ -2157,6 +2174,8 @@ var fumifier = (function() {
       exec_env.executionId = executionId;
       exec_env.bind('executionId', executionId);
     }
+
+    exec_env.bind(regexEvalCacheSymbol, new WeakMap());
 
     exec_env.bind('$', input);
 

--- a/src/fumifier.js
+++ b/src/fumifier.js
@@ -1376,7 +1376,21 @@ var fumifier = (function() {
       flags += 'g';
     }
 
-    var re = new RegExp(pattern, flags);
+    var re;
+    try {
+      re = new RegExp(pattern, flags);
+    } catch (err) {
+      throw new FumifierError('S0303', undefined, {
+        position: expr.position,
+        start: expr.start,
+        line: expr.line,
+        value: `/${pattern}/${flags}`,
+        sourceMessage: err.message,
+        sourceError: err,
+        stack: err.stack || (new Error()).stack
+      });
+    }
+
     var closure = function(str, fromIndex) {
       var result;
       re.lastIndex = fromIndex || 0;

--- a/src/parser.js
+++ b/src/parser.js
@@ -468,6 +468,37 @@ const parser = (() => {
       return s;
     };
 
+    const missingRhsTerminatorIds = new Set(['(end)', ')', ']', '}', ';', ',', '(indent)', '(instanceof)', 'Instance:']);
+
+    var missingRhsError = function (operatorToken) {
+      var err = {
+        code: 'S0218',
+        token: operatorToken.value,
+        position: operatorToken.position,
+        start: operatorToken.start,
+        line: operatorToken.line
+      };
+
+      if (recover) {
+        errors.push(err);
+        return {
+          type: 'error',
+          error: err
+        };
+      }
+
+      err.stack = (new Error()).stack;
+      throw err;
+    };
+
+    var parseRequiredRhs = function (operatorToken, bindingPower) {
+      if (missingRhsTerminatorIds.has(node.id)) {
+        return missingRhsError(operatorToken);
+      }
+
+      return expression(bindingPower);
+    };
+
     terminal("(end)");
     terminal("(name)");
     terminal("(literal)");
@@ -481,7 +512,12 @@ const parser = (() => {
     infix("+"); // numeric addition
     infix("-"); // numeric subtraction
     infix("*"); // numeric multiplication
-    infix("/"); // numeric division
+    infix("/", operators['/'], function (left) {
+      this.lhs = left;
+      this.rhs = parseRequiredRhs(this, operators['/']);
+      this.type = "binary";
+      return this;
+    }); // numeric division
     infix("="); // equality OR assignment in FLASH rules (inline value assignment)
     infix("<"); // less than
     infix(">"); // greater than
@@ -1495,7 +1531,7 @@ const parser = (() => {
         });
       }
       this.lhs = left;
-      this.rhs = expression(operators[':='] - 1); // subtract 1 from bindingPower for right associative operators
+      this.rhs = parseRequiredRhs(this, operators[':='] - 1); // subtract 1 from bindingPower for right associative operators
       this.type = "binary";
       return this;
     });

--- a/src/parser.js
+++ b/src/parser.js
@@ -58,6 +58,22 @@ const parser = (() => {
     var symbol_table = {};
     var errors = [];
 
+    var toSimpleToken = function (token) {
+      var simpleToken = {
+        type: token.type,
+        value: token.value,
+        position: token.position,
+        line: token.line,
+        start: token.start
+      };
+
+      if (Object.prototype.hasOwnProperty.call(token, 'flags')) {
+        simpleToken.flags = token.flags;
+      }
+
+      return simpleToken;
+    };
+
     var tokenLeavesLeftContext = function(token) {
       if (!token) {
         return false;
@@ -83,12 +99,12 @@ const parser = (() => {
       var remaining = [];
       var hasLeftContext = false;
       if (node.id !== '(end)') {
-        remaining.push({type: node.type, value: node.value, position: node.position, line: node.line, start: node.start});
+        remaining.push(toSimpleToken(node));
         hasLeftContext = tokenLeavesLeftContext(node);
       }
       var nxt = lexer.next(hasLeftContext);
       while (nxt !== null) {
-        remaining.push(nxt);
+        remaining.push(toSimpleToken(nxt));
         hasLeftContext = tokenLeavesLeftContext(nxt);
         nxt = lexer.next(hasLeftContext);
       }
@@ -328,6 +344,9 @@ const parser = (() => {
       node.position = next_token.position;
       node.start = next_token.start;
       node.line = next_token.line;
+      if (Object.prototype.hasOwnProperty.call(next_token, 'flags')) {
+        node.flags = next_token.flags;
+      }
       return node;
     };
 

--- a/src/parser.js
+++ b/src/parser.js
@@ -58,15 +58,39 @@ const parser = (() => {
     var symbol_table = {};
     var errors = [];
 
+    var tokenLeavesLeftContext = function(token) {
+      if (!token) {
+        return false;
+      }
+
+      switch (token.type) {
+        case 'name':
+        case 'variable':
+        case 'number':
+        case 'string':
+        case 'value':
+        case 'regex':
+        case 'url':
+          return true;
+        case 'operator':
+          return token.value === ')' || token.value === ']' || token.value === '}';
+        default:
+          return false;
+      }
+    };
+
     var remainingTokens = function () {
       var remaining = [];
+      var hasLeftContext = false;
       if (node.id !== '(end)') {
         remaining.push({type: node.type, value: node.value, position: node.position, line: node.line, start: node.start});
+        hasLeftContext = tokenLeavesLeftContext(node);
       }
-      var nxt = lexer.next();
+      var nxt = lexer.next(hasLeftContext);
       while (nxt !== null) {
         remaining.push(nxt);
-        nxt = lexer.next();
+        hasLeftContext = tokenLeavesLeftContext(nxt);
+        nxt = lexer.next(hasLeftContext);
       }
       return remaining;
     };
@@ -150,10 +174,10 @@ const parser = (() => {
          * to the token variable.
          * It can take an optional id parameter which it can check against the id of the previous token.
          * @param {string} id checked against the id of the previous token
-         * @param {boolean} infix
+        * @param {boolean} hasLeftContext true when the next token has something to its left
          * @returns token (node)
          */
-    var advance = function (id, infix) {
+    var advance = function (id, hasLeftContext) {
       // In Crockford's implementation, we assume that the source text has been transformed into an array of simple token
       // objects (tokens), each containing a type (string) and a value (string or number).
       // In this implementation, the token array is built as we go, and the next token is returned by the lexer (next() function)
@@ -198,7 +222,7 @@ const parser = (() => {
         indent = node.value; // Set to previous node's line
       }
       /** Fetch next simple token from the scanner */
-      var next_token = lexer.next(infix);
+      var next_token = lexer.next(hasLeftContext);
       if (next_token === null) {
         // When the scanner has no more tokens to consume from the source it returns null
         // So we create an (end) token and return it, but not before we override the node variable
@@ -220,7 +244,7 @@ const parser = (() => {
           node.type === 'instance'
         );
         if (!previousStartsFlashBlock) {
-          next_token = lexer.next(infix);
+          next_token = lexer.next(hasLeftContext);
         }
       }
       /** Start preparing the processed token to return and override the `node` var with */
@@ -270,7 +294,7 @@ const parser = (() => {
           // var indentSymbol = symbol_table["(indent)"];
           var indentValue = next_token.value; // this is the indent number
           // go to next token
-          next_token = lexer.next(infix);
+          next_token = lexer.next(hasLeftContext);
           /* c8 ignore else */
           if (next_token.type === 'operator' && next_token.value === 'Instance:') {
             // It's a FLASH Instance: delaration

--- a/src/utils/errorCodes.js
+++ b/src/utils/errorCodes.js
@@ -105,6 +105,7 @@ const errorCodes = {
   "S0218": "The right side of {{token}} is missing",
   "S0301": "Empty regular expressions are not allowed",
   "S0302": "No terminating / in regular expression",
+  "S0303": "Invalid regular expression literal {{value}}: {{{sourceMessage}}}",
   "S0402": "Choice groups containing parameterized types are not supported",
   "S0401": "Type parameters can only be applied to functions and arrays",
   "S0500": "Attempted to evaluate an expression containing syntax error(s)",

--- a/src/utils/errorCodes.js
+++ b/src/utils/errorCodes.js
@@ -102,6 +102,7 @@ const errorCodes = {
   "S0215": "A context variable binding must precede any predicates on a step",
   "S0216": "A context variable binding must precede the 'order-by' clause on a step",
   "S0217": "The object representing the 'parent' cannot be derived from this expression",
+  "S0218": "The right side of {{token}} is missing",
   "S0301": "Empty regular expressions are not allowed",
   "S0302": "No terminating / in regular expression",
   "S0402": "Choice groups containing parameterized types are not supported",

--- a/src/utils/tokenizer.js
+++ b/src/utils/tokenizer.js
@@ -37,10 +37,11 @@ export default function (path) {
   /**
      * Creates a token object with type, value, and position.
      * @param {string} type - The type of the token (e.g., 'operator', 'string', 'number', 'name').
-     * @param {string|number|RegExp} value - The value of the token.
+     * @param {string|number|boolean|null} value - The value of the token.
+     * @param {object} [extraProps] - Optional extra token properties.
      * @returns {object} A token object containing type, value, and the current position.
      */
-  var create = function (type, value) {
+  var create = function (type, value, extraProps) {
     var obj = {
       type,
       value,
@@ -48,17 +49,18 @@ export default function (path) {
       start,              // start position (added for better error marking in FUME)
       line                // line number (added for clear error reporting in FUME)
     };
+    if (extraProps) {
+      Object.assign(obj, extraProps);
+    }
     previousToken = obj;
     return obj;
   };
 
-  var scanRegex = function () {
+  var scanRegex = function (literalStart) {
     // the prefix '/' will have been previously scanned. Find the end of the regex.
     // search for closing '/' ignoring any that are escaped, or within brackets
-    start = position;
+    var patternStart = position;
     var depth = 0;
-    var pattern;
-    var flags;
 
     var isClosingSlash = function (position) {
       if (path.charAt(position) === '/' && depth === 0) {
@@ -77,17 +79,20 @@ export default function (path) {
       var currentChar = path.charAt(position);
       if (isClosingSlash(position)) {
         // end of regex found
-        pattern = path.substring(start, position);
+        var pattern = path.substring(patternStart, position);
         position++;
         currentChar = path.charAt(position);
         // flags
-        start = position;
+        var flagsStart = position;
         while (currentChar === 'i' || currentChar === 'm') {
           position++;
           currentChar = path.charAt(position);
         }
-        flags = path.substring(start, position) + 'g';
-        return new RegExp(pattern, flags);
+        return {
+          value: pattern,
+          flags: path.substring(flagsStart, position) + 'g',
+          start: literalStart
+        };
       }
       if ((currentChar === '(' || currentChar === '[' || currentChar === '{') && path.charAt(position - 1) !== '\\') {
         depth++;
@@ -102,7 +107,7 @@ export default function (path) {
       code: "S0302",
       stack: (new Error()).stack,
       position,
-      start,
+      start: literalStart,
       line
     };
   };
@@ -299,8 +304,13 @@ export default function (path) {
     }
     // test for regex
     if (hasLeftContext !== true && currentChar === '/') {
+      var literalStart = position;
       position++;
-      return create('regex', scanRegex());
+      var regexToken = scanRegex(literalStart);
+      return create('regex', regexToken.value, {
+        flags: regexToken.flags,
+        start: regexToken.start
+      });
     }
     // handle double-char operators
     if (currentChar === '.' && path.charAt(position + 1) === '.') {

--- a/src/utils/tokenizer.js
+++ b/src/utils/tokenizer.js
@@ -88,9 +88,26 @@ export default function (path) {
           position++;
           currentChar = path.charAt(position);
         }
+        var rawFlags = path.substring(flagsStart, position);
+        var compiledFlags = rawFlags + 'g';
+
+        try {
+          new RegExp(pattern, compiledFlags);
+        } catch (err) {
+          throw {
+            code: 'S0303',
+            stack: (new Error()).stack,
+            position,
+            start: literalStart,
+            line,
+            value: `/${pattern}/${rawFlags}`,
+            sourceMessage: err.message
+          };
+        }
+
         return {
           value: pattern,
-          flags: path.substring(flagsStart, position) + 'g',
+          flags: compiledFlags,
           start: literalStart
         };
       }

--- a/src/utils/tokenizer.js
+++ b/src/utils/tokenizer.js
@@ -133,16 +133,14 @@ export default function (path) {
   /**
      * Advances to the next simple token and returns it.
      * This is entirely sequential - no nesting and operator precedence logic is done here
-     * @param {boolean} prefix - This essentially tells the scanner that the next token is going to be
-     *      used as a prefix - the beginning of a subexpression.
-     *      This is explicitly set to true only in the first call to advance() from expression().
+     * @param {boolean} hasLeftContext - True when the next token has something to its left.
      *      The only use for this flag currently is to tell the scanner how to treat the '/' operator.
-     *      When / is used as prefix, everything up to the next '/' should not be tokenized but rather
-     *      "swallowed" as the value of a regex token.
-     *      When '/' is used an infix, it is just the regular division operator.
+     *      When the next token has left context, '/' is tokenized as the division operator.
+     *      Otherwise '/' starts a regex literal and everything up to the next unescaped closing '/'
+     *      is swallowed into a regex token.
      * @returns {object|null} The next token object or null if end of input.
      */
-  var next = function (prefix) {
+  var next = function (hasLeftContext) {
     if (position >= length) return null;
     var currentChar = path.charAt(position);
     // skip whitespace - but keep track of new lines and indentation
@@ -238,7 +236,7 @@ export default function (path) {
       }
       position += 2;
       currentChar = path.charAt(position);
-      return next(prefix); // need this to swallow any following whitespace
+      return next(hasLeftContext); // need this to swallow any following whitespace
     }
     start = position; // remember the start of the token
     // FUME: capture URL's (including URN's)
@@ -271,7 +269,7 @@ export default function (path) {
         currentChar = path.charAt(++position);
       }
       // currentChar = path.charAt(position);
-      return next(prefix); // need this to swallow any following whitespace
+      return next(hasLeftContext); // need this to swallow any following whitespace
     }
     start = position; // remember the start of the token
     // handle flash block declarations ("Instance:", "InstanceOf:" and "* " rules)
@@ -300,7 +298,7 @@ export default function (path) {
       return token;
     }
     // test for regex
-    if (prefix !== true && currentChar === '/') {
+    if (hasLeftContext !== true && currentChar === '/') {
       position++;
       return create('regex', scanRegex());
     }
@@ -520,12 +518,12 @@ export default function (path) {
    * To allow context aware parsing, we need to be able to look ahead
    * without consuming the token. This function will return the next token
    * without consuming it, so that it can be used later.
-   * @param {*} prefix see `next()` for details
+   * @param {*} hasLeftContext see `next()` for details
    * @returns {object} the next token, or the peeked token if available
    */
-  function peek(prefix) {
+  function peek(hasLeftContext) {
     if (peeked === null) {
-      peeked = next(prefix);
+      peeked = next(hasLeftContext);
     }
     return peeked;
   }

--- a/test/ast-mobility.test.js
+++ b/test/ast-mobility.test.js
@@ -295,6 +295,24 @@ describe('AST Mobility Feature', function() {
     }, /Invalid AST/);
   });
 
+  it('should throw a structured error for invalid regex metadata in AST input', async function() {
+    const invalidRegexAst = {
+      type: 'regex',
+      value: 'foo',
+      flags: 'iig',
+      position: 8,
+      start: 0,
+      line: 1
+    };
+
+    const compiled = await fumifier(invalidRegexAst);
+
+    await assert.rejects(
+      async () => await compiled.evaluate({}),
+      (err) => err.code === 'S0303' && err.position === 8 && err.start === 0 && err.line === 1 && err.value === '/foo/iig'
+    );
+  });
+
   it('should throw error for invalid input types', async function() {
     // Test null
     await assert.rejects(async () => {

--- a/test/ast-mobility.test.js
+++ b/test/ast-mobility.test.js
@@ -5,6 +5,35 @@ import { FhirSnapshotGenerator } from "fhir-snapshot-generator";
 import { FhirTerminologyRuntime } from "fhir-terminology-runtime";
 import { FhirPackageExplorer } from "fhir-package-explorer";
 
+function findNodeByType(value, type) {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+
+  if (value.type === type) {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const match = findNodeByType(item, type);
+      if (match) {
+        return match;
+      }
+    }
+    return null;
+  }
+
+  for (const candidate of Object.values(value)) {
+    const match = findNodeByType(candidate, type);
+    if (match) {
+      return match;
+    }
+  }
+
+  return null;
+}
+
 describe('AST Mobility Feature', function() {
   let navigator;
   let terminologyRuntime;
@@ -177,6 +206,37 @@ describe('AST Mobility Feature', function() {
 
     assert.equal(originalResult, recreatedResult);
     assert.equal(originalResult, "Hello World");
+  });
+
+  it('should preserve regex metadata across AST JSON round-trips', async function() {
+    const originalExpr = await fumifier('/a(b+)/i ("Ababbabbcc")');
+    const originalAst = originalExpr.ast();
+    const originalRegexNode = findNodeByType(originalAst, 'regex');
+
+    assert.ok(originalRegexNode, 'Expected a regex node in the original AST');
+    assert.deepEqual(originalRegexNode, {
+      type: 'regex',
+      value: 'a(b+)',
+      flags: 'ig',
+      position: 8,
+      start: 0,
+      line: 1
+    });
+
+    const astJson = JSON.stringify(originalAst);
+    const deserializedAst = JSON.parse(astJson);
+    const deserializedRegexNode = findNodeByType(deserializedAst, 'regex');
+
+    assert.ok(deserializedRegexNode, 'Expected a regex node after JSON round-trip');
+    assert.deepEqual(deserializedRegexNode, originalRegexNode,
+      'Regex node metadata should survive JSON serialization');
+
+    const recreatedExpr = await fumifier(deserializedAst);
+    const originalResult = await originalExpr.evaluate({});
+    const recreatedResult = await recreatedExpr.evaluate({});
+
+    assert.deepEqual(recreatedResult, originalResult);
+    assert.deepEqual(recreatedResult, { match: 'Ab', start: 0, end: 2, groups: ['b'] });
   });
 
   it('should handle AST with errors (recovery mode)', async function() {

--- a/test/ast-mobility.test.js
+++ b/test/ast-mobility.test.js
@@ -34,6 +34,19 @@ function findNodeByType(value, type) {
   return null;
 }
 
+function simplifyRegexMatch(result) {
+  if (!result) {
+    return result;
+  }
+
+  return {
+    match: result.match,
+    start: result.start,
+    end: result.end,
+    groups: result.groups
+  };
+}
+
 describe('AST Mobility Feature', function() {
   let navigator;
   let terminologyRuntime;
@@ -235,8 +248,11 @@ describe('AST Mobility Feature', function() {
     const originalResult = await originalExpr.evaluate({});
     const recreatedResult = await recreatedExpr.evaluate({});
 
-    assert.deepEqual(recreatedResult, originalResult);
-    assert.deepEqual(recreatedResult, { match: 'Ab', start: 0, end: 2, groups: ['b'] });
+    assert.deepEqual(simplifyRegexMatch(recreatedResult), simplifyRegexMatch(originalResult));
+    assert.deepEqual(simplifyRegexMatch(recreatedResult), { match: 'Ab', start: 0, end: 2, groups: ['b'] });
+    assert.equal(typeof originalResult.next, 'function');
+    assert.equal(typeof recreatedResult.next, 'function');
+    assert.deepEqual(simplifyRegexMatch(recreatedResult.next()), simplifyRegexMatch(originalResult.next()));
   });
 
   it('should handle AST with errors (recovery mode)', async function() {

--- a/test/browser-entry.test.js
+++ b/test/browser-entry.test.js
@@ -191,6 +191,22 @@ describe('Browser Entry Point', function() {
       assert(tokens.length > 0, 'Should return tokens');
       assert(tokens[0].type === 'regex', 'First token should be a regex literal');
     });
+
+    it('should preserve regex token coordinates in browser tokenization', function() {
+      const { tokenize } = browserModuleEsm;
+      const tokens = tokenize('/foo/im');
+
+      assert(Array.isArray(tokens), 'Should return an array');
+      assert.equal(tokens.length, 1, 'Standalone regex should be emitted as a single token');
+      assert.deepEqual(tokens[0], {
+        type: 'regex',
+        value: 'foo',
+        flags: 'img',
+        start: 0,
+        end: 7,
+        line: 1
+      });
+    });
   });
 
   describe('Browser Isolation', function() {

--- a/test/browser-entry.test.js
+++ b/test/browser-entry.test.js
@@ -89,6 +89,14 @@ describe('Browser Entry Point', function() {
       }, 'Should throw on incomplete expression');
     });
 
+    it('should throw a structured error for invalid regex literals', function() {
+      const { parse } = browserModuleEsm;
+
+      assert.throws(() => {
+        parse('/foo/ii');
+      }, (err) => err.code === 'S0303' && err.start === 0 && err.position === 7);
+    });
+
     it('should return errors in AST when recover=true', function() {
       const { parse } = browserModuleEsm;
       const ast = parse('name.first &', true);
@@ -119,6 +127,20 @@ describe('Browser Entry Point', function() {
       assert(result.isValid === false, 'Invalid expression should be marked as invalid');
       assert(result.errors.length > 0, 'Invalid expression should have errors');
       assert(typeof result.errors[0].code === 'string', 'Errors should have error codes');
+    });
+
+    it('should report structured errors for invalid regex literals', function() {
+      const { validate } = browserModuleEsm;
+      const result = validate('/foo/ii');
+
+      assert(result.isValid === false, 'Invalid regex literal should be invalid');
+      assert.equal(result.errors[0].code, 'S0303');
+      assert.equal(result.errors[0].position, 7);
+      assert.equal(result.errors[0].start, 0);
+      assert.equal(result.errors[0].line, 1);
+      assert.equal(result.errors[0].value, '/foo/ii');
+      assert.equal(result.errors[0].type, 'ParseError');
+      assert.match(result.errors[0].message, /^Invalid regular expression literal "\/foo\/ii": /);
     });
 
     it('should handle non-string input gracefully', function() {

--- a/test/implementation-tests.test.js
+++ b/test/implementation-tests.test.js
@@ -725,6 +725,34 @@ describe("Tests that are specific to a Javascript runtime", () => {
     });
   });
 
+  describe('["ab","bc","ad"][$match($,/a./)]', function() {
+    it('should compile the inline regex once per evaluation context', async function() {
+      var expr = await fumifier('["ab","bc","ad"][$match($,/a./)]');
+      var OriginalRegExp = globalThis.RegExp;
+      var regexCompileCount = 0;
+
+      function CountingRegExp(pattern, flags) {
+        regexCompileCount++;
+        return new OriginalRegExp(pattern, flags);
+      }
+
+      Object.setPrototypeOf(CountingRegExp, OriginalRegExp);
+      CountingRegExp.prototype = OriginalRegExp.prototype;
+      globalThis.RegExp = CountingRegExp;
+
+      try {
+        var firstResult = await expr.evaluate();
+        var secondResult = await expr.evaluate();
+
+        expect(firstResult).to.deep.equal(["ab", "ad"]);
+        expect(secondResult).to.deep.equal(["ab", "ad"]);
+        expect(regexCompileCount).to.equal(2);
+      } finally {
+        globalThis.RegExp = OriginalRegExp;
+      }
+    });
+  });
+
   // skipped due to possible collision with the addition of single line comments //
   describe("empty regex", function() {
     it("should throw error", async function() {

--- a/test/parser-recovery.test.js
+++ b/test/parser-recovery.test.js
@@ -500,4 +500,70 @@ describe('Recover mode JSONata parsing', function() {
     assert(Array.isArray(errors), 'Expected errors() to return an array');
     assert(errors.length > 0, 'Expected at least one recoverable parse error');
   });
+
+  it('should keep the assignment-side error primary after recovery before a later division slash', async function() {
+    const compiled = await fumifier('$resourceTypes := ;\n$reqCount := $ceil($count($refChunk)/$maxIdsPerRequest);', {
+      recover: true,
+      navigator: undefined
+    });
+    const errors = compiled.errors();
+
+    assert.ok(compiled.ast(), 'Expected recover mode to still return an AST');
+    assert(Array.isArray(errors), 'Expected errors() to return an array');
+    assert(errors.length > 0, 'Expected at least one recoverable parse error');
+    assert.deepEqual(errors[0], {
+      code: 'S0218',
+      token: ':=',
+      line: 1,
+      position: 17,
+      start: 15
+    });
+    assert.equal(errors.find(error => error.code === 'S0302'), undefined,
+      'Recovery should not reinterpret the later division slash as a regex literal');
+  });
+
+  it('should report missing RHS for division at end of input', async function() {
+    const compiled = await fumifier('1/', { recover: true, navigator: undefined });
+    const errors = compiled.errors();
+
+    assert.ok(compiled.ast(), 'Expected recover mode to still return an AST');
+    assert(Array.isArray(errors), 'Expected errors() to return an array');
+    assert.deepEqual(errors[0], {
+      code: 'S0218',
+      token: '/',
+      line: 1,
+      position: 2,
+      start: 1
+    });
+  });
+
+  it('should keep missing RHS for division primary before a closing paren error', async function() {
+    const compiled = await fumifier('(1/)', { recover: true, navigator: undefined });
+    const errors = compiled.errors();
+
+    assert.ok(compiled.ast(), 'Expected recover mode to still return an AST');
+    assert(Array.isArray(errors), 'Expected errors() to return an array');
+    assert.deepEqual(errors[0], {
+      code: 'S0218',
+      token: '/',
+      line: 1,
+      position: 3,
+      start: 2
+    });
+  });
+
+  it('should keep missing RHS for division primary for incomplete parenthesized expressions', async function() {
+    const compiled = await fumifier('(1/', { recover: true, navigator: undefined });
+    const errors = compiled.errors();
+
+    assert.ok(compiled.ast(), 'Expected recover mode to still return an AST');
+    assert(Array.isArray(errors), 'Expected errors() to return an array');
+    assert.deepEqual(errors[0], {
+      code: 'S0218',
+      token: '/',
+      line: 1,
+      position: 3,
+      start: 2
+    });
+  });
 });


### PR DESCRIPTION
## Problem

This change hardens parser and tokenizer behavior around slash handling, regex metadata, and recovery-mode diagnostics.

Before this change:

- A syntax error earlier in an expression could cause recovery-mode rescans to reinterpret a later division slash as the start of a regex literal and emit `S0302` instead of the real parse error.
- Missing RHS cases such as `1/`, `(1/)`, and `$x := ;` degraded into generic EOF or delimiter errors instead of pointing at the operator that actually needed an operand.
- Regex tokens and AST nodes exposed live compiled `RegExp` objects and unstable coordinates, which made browser tokenization contracts unclear and broke JSON-based AST mobility.
- The same regex AST node could be recompiled repeatedly during a single evaluation when used inside per-item flows such as filters.

## Root Cause

- Recovery-mode token collection in the parser consumed the remaining token stream without preserving slash context, so `/` could flip from division to regex during error handling.
- Infix operators delegated directly to generic RHS parsing, which let downstream unmatched delimiters or EOF conditions outrank the operator-local defect.
- `scanRegex()` returned a live `RegExp` and reused shared tokenizer start state while scanning flags, so regex token coordinates and exported payload shape were both unstable.
- Runtime regex preparation had no per-evaluation memoization, so repeated evaluation of the same regex node rebuilt the matcher unnecessarily.

## What Changed

- Normalized slash-context handling to an explicit `hasLeftContext` model across parser and tokenizer code.
- Made recovery-mode rescans context-aware so later division operators remain division operators after an earlier syntax error.
- Added `S0218` (`The right side of {{token}} is missing`) and applied it to `/` and `:=` so the primary diagnostic stays anchored on the operator.
- Changed exported regex token and AST payloads to a serializable shape:
  - `type: 'regex'`
  - `value: <pattern string>`
  - `flags: <flags string>`
  - stable `start`, `position`/`end`, and `line`
- Removed live compiled `RegExp` objects from exported ASTs and browser token arrays.
- Updated runtime regex evaluation to compile from AST metadata and memoize once per evaluation context, without sharing mutable `lastIndex` state across separate `evaluate()` calls.

## Issue Mapping

- Resolves #83: fixed by context-aware recovery rescans plus operator-local missing-RHS precedence.
- Resolves #90: fixed by stable regex token/AST metadata and explicit regression coverage for browser tokenization and AST mobility.
- Resolves #91: fixed by `S0218` precedence on `/` and `:=` when the RHS is missing.

## Scope Exclusions

- No broader parser error-taxonomy redesign beyond `S0218`.
- No unrelated tokenizer cleanup.
- No FSH package rebuild or regeneration of committed FSH-derived artifacts.

## Compatibility Notes

- This intentionally changes the exported AST and browser token-array contract for regex literals.
- Regex nodes/tokens no longer expose live `RegExp` instances.
- The canonical exported representation is now serializable metadata (`value` + `flags` + coordinates).

## Validation

- Focused parser/browser/AST suite:
  - `npx mocha test/parser-recovery.test.js test/browser-entry.test.js test/browser-compatibility.test.js test/implementation-tests.test.js test/ast-mobility.test.js --timeout=20000`
  - Result: `119 passing`, `1 pending`, `0 failing`
- Broader Mocha sanity pass:
  - `npx mocha "test/**/*.test.js" --timeout=20000`
  - Result: completed successfully with exit code `0`; output ended with `1 pending`

## Risk Notes

- The exported regex payload shape is a deliberate breaking change for any unknown consumer that inspected `ast()` or browser `tokenize()` results as live `RegExp` objects.
- Regex memoization is intentionally scoped per evaluation context to avoid leaking mutable matcher state across separate evaluations.
- Slash-context behavior now has explicit regression coverage in recovery mode, browser tokenization, and AST mobility paths.