### PR TITLE
Fix FLASH wildcard variable assignment parsing

### DIFF
--- a/release-notes-issue-84-wildcard-variable.md
+++ b/release-notes-issue-84-wildcard-variable.md
@@ -1,0 +1,24 @@
+# Draft Release Notes: FLASH Wildcard Variable Parsing
+
+This release fixes a FLASH parser issue affecting wildcard variable assignments inside FLASH blocks.
+
+## Highlights
+
+- FLASH now accepts bare wildcard variable assignments such as `$value := *;` in places where FLASH already expects a value expression.
+- The unwrapped form now behaves the same as the existing parenthesized workaround `$value := (*);`.
+- Existing malformed-rule protections remain in place for empty `*` rules and malformed double-star rules.
+
+## User-Visible Correction
+
+- Fixed cases where `$value := *;` could be rejected as `F1024` (`Malformed FLASH rule: Rule is empty`) even though the equivalent parenthesized form parsed successfully.
+
+## Compatibility Notes
+
+- No public API changes.
+- Existing parenthesized expressions continue to work.
+- Users who adopted the parenthesized workaround do not need to change existing expressions.
+
+## Validation Summary
+
+- Focused wildcard-hardening regression coverage passed.
+- Parser recovery regression coverage passed.

--- a/src/parser.js
+++ b/src/parser.js
@@ -49,7 +49,7 @@ const parser = (() => {
      * When off, indent tokens are ignored entirely and regular JSONata mode is used where indents are not significant.
      */
     var indentAwareMode = false;
-    var parsingFlashInlineExpression = false;
+    var parsingFlashValueExpression = false;
 
     /**
      * Every token, such as an operator or identifier, will inherit from a symbol.
@@ -893,7 +893,7 @@ const parser = (() => {
     // field wildcard (single level) OR flash rule
     prefix('*', function () {
       var { position, line, start } = this;
-      if (indentAwareMode && parsingFlashInlineExpression) {
+      if (indentAwareMode && parsingFlashValueExpression) {
         this.type = 'wildcard';
         return this;
       }
@@ -917,11 +917,11 @@ const parser = (() => {
         if (node.id === '=') {
           advance('=');
           if (node.id !== '(end)' && node.id !== '(indent)') {
-            parsingFlashInlineExpression = true;
+            parsingFlashValueExpression = true;
             try {
               this.inlineExpression = expression(0);
             } finally {
-              parsingFlashInlineExpression = false;
+              parsingFlashValueExpression = false;
             }
             // Allow optional trailing semicolon after inline expression for backwards compatibility
             if (node.id === ';') {

--- a/src/parser.js
+++ b/src/parser.js
@@ -1550,7 +1550,16 @@ const parser = (() => {
         });
       }
       this.lhs = left;
-      this.rhs = parseRequiredRhs(this, operators[':='] - 1); // subtract 1 from bindingPower for right associative operators
+      if (indentAwareMode) {
+        parsingFlashValueExpression = true;
+        try {
+          this.rhs = parseRequiredRhs(this, operators[':='] - 1); // subtract 1 from bindingPower for right associative operators
+        } finally {
+          parsingFlashValueExpression = false;
+        }
+      } else {
+        this.rhs = parseRequiredRhs(this, operators[':='] - 1); // subtract 1 from bindingPower for right associative operators
+      }
       this.type = "binary";
       return this;
     });

--- a/test/flash-parser-hardening.test.js
+++ b/test/flash-parser-hardening.test.js
@@ -57,7 +57,7 @@ function findFirstBindExpression(node) {
     return undefined;
   }
 
-  if (node.type === 'binary' && node.value === ':=') {
+  if (node.type === 'bind') {
     return node;
   }
 

--- a/test/flash-parser-hardening.test.js
+++ b/test/flash-parser-hardening.test.js
@@ -32,6 +32,10 @@ const malformedDoubleStarExpression = `InstanceOf: Patient
 * address
   * * valueString = 'x'`;
 
+const malformedEmptyRuleExpression = `InstanceOf: Patient
+* address
+  *`;
+
 function findInlineWildcards(node, found = []) {
   if (!node || typeof node !== 'object') {
     return found;
@@ -163,6 +167,20 @@ describe('FLASH parser hardening regression', function() {
     assert.equal(ast.errors[0].start, malformedWildcardStart);
   });
 
+  it('should preserve F1024 error locations for truly empty FLASH rules in recover=true mode', function() {
+    const ast = parse(malformedEmptyRuleExpression, true);
+    const malformedRuleStart = malformedEmptyRuleExpression.lastIndexOf('*');
+
+    assert(ast, 'Expected recover=true parsing to return an AST');
+    assert(Array.isArray(ast.errors), 'Expected malformed recover-mode parse to attach errors');
+    assert.equal(ast.errors.length, 1, 'Expected a single malformed rule error');
+    assert.equal(ast.errors[0].code, 'F1024');
+    assert.equal(ast.errors[0].line, 3);
+    assert.equal(ast.errors[0].position, malformedRuleStart + 1);
+    assert.equal(ast.errors[0].start, malformedRuleStart);
+    assert.equal(ast.errors[0].token, '(end)');
+  });
+
   it('should validate the unwrapped expression as valid', function() {
     const result = validate(issueExpression);
 
@@ -184,6 +202,17 @@ describe('FLASH parser hardening regression', function() {
       () => parse(malformedDoubleStarExpression, false),
       (error) => {
         assert.equal(error.code, 'F1022');
+        assert.equal(error.line, 3);
+        return true;
+      }
+    );
+  });
+
+  it('should still reject truly empty FLASH rules with F1024', function() {
+    assert.throws(
+      () => parse(malformedEmptyRuleExpression, false),
+      (error) => {
+        assert.equal(error.code, 'F1024');
         assert.equal(error.line, 3);
         return true;
       }

--- a/test/flash-parser-hardening.test.js
+++ b/test/flash-parser-hardening.test.js
@@ -18,6 +18,16 @@ const parenthesizedControlExpression = `InstanceOf: Patient
     * ({'k': $}).extension[http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-streetName]
       * valueString = (*)`;
 
+const issue84Expression = `InstanceOf: Patient
+* ({'a': 'b'}).identifier
+  $value := *;
+  * value = $value`;
+
+const issue84ParenthesizedControlExpression = `InstanceOf: Patient
+* ({'a': 'b'}).identifier
+  $value := (*);
+  * value = $value`;
+
 const malformedDoubleStarExpression = `InstanceOf: Patient
 * address
   * * valueString = 'x'`;
@@ -40,6 +50,34 @@ function findInlineWildcards(node, found = []) {
   }
 
   return found;
+}
+
+function findFirstBindExpression(node) {
+  if (!node || typeof node !== 'object') {
+    return undefined;
+  }
+
+  if (node.type === 'binary' && node.value === ':=') {
+    return node;
+  }
+
+  for (const value of Object.values(node)) {
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        const found = findFirstBindExpression(item);
+        if (found) {
+          return found;
+        }
+      }
+    } else {
+      const found = findFirstBindExpression(value);
+      if (found) {
+        return found;
+      }
+    }
+  }
+
+  return undefined;
 }
 
 describe('FLASH parser hardening regression', function() {
@@ -86,6 +124,32 @@ describe('FLASH parser hardening regression', function() {
     assert.equal(ast.errors, undefined);
   });
 
+  it('should parse bare wildcard variable assignments successfully when recover=false', function() {
+    const ast = parse(issue84Expression, false);
+
+    assert(ast, 'Expected the unwrapped wildcard variable assignment to parse');
+    assert.equal(ast.containsFlash, true, 'Expected FLASH syntax to be detected');
+    assert.equal(ast.errors, undefined);
+  });
+
+  it('should also parse bare wildcard variable assignments in recover=true mode without attaching errors', function() {
+    const ast = parse(issue84Expression, true);
+
+    assert(ast, 'Expected recover=true parsing to return an AST for the wildcard variable assignment');
+    assert.equal(ast.errors, undefined);
+  });
+
+  it('should produce a wildcard RHS for the bare := assignment', function() {
+    const ast = parse(issue84Expression, false);
+    const bindExpression = findFirstBindExpression(ast);
+
+    assert(bindExpression, 'Expected to find a := binding in the parsed AST');
+    assert.equal(bindExpression.rhs.type, 'wildcard');
+    assert.equal(bindExpression.rhs.line, 3);
+    assert.equal(typeof bindExpression.rhs.position, 'number');
+    assert(bindExpression.rhs.position >= issue84Expression.indexOf('$value := *;'));
+  });
+
   it('should preserve error locations for malformed FLASH rules in recover=true mode', function() {
     const ast = parse(malformedDoubleStarExpression, true);
     const malformedWildcardStart = malformedDoubleStarExpression.lastIndexOf('*');
@@ -101,6 +165,14 @@ describe('FLASH parser hardening regression', function() {
 
   it('should validate the unwrapped expression as valid', function() {
     const result = validate(issueExpression);
+
+    assert.equal(result.isValid, true);
+    assert(Array.isArray(result.errors), 'Expected validate() to return an errors array');
+    assert.equal(result.errors.length, 0);
+  });
+
+  it('should validate the wildcard variable assignment expression as valid', function() {
+    const result = validate(issue84Expression);
 
     assert.equal(result.isValid, true);
     assert(Array.isArray(result.errors), 'Expected validate() to return an errors array');
@@ -125,6 +197,13 @@ describe('FLASH parser hardening regression', function() {
     assert.equal(ast.containsFlash, true, 'Expected FLASH syntax to be detected');
   });
 
+  it('should still parse the parenthesized wildcard variable assignment workaround', function() {
+    const ast = parse(issue84ParenthesizedControlExpression, false);
+
+    assert(ast, 'Expected the parenthesized wildcard variable assignment control to parse');
+    assert.equal(ast.containsFlash, true, 'Expected FLASH syntax to be detected');
+  });
+
   it('should evaluate the unwrapped and parenthesized expressions to the same Patient output', async function() {
     const unwrapped = await fumifier(issueExpression, { navigator, terminologyRuntime });
     const wrapped = await fumifier(parenthesizedControlExpression, { navigator, terminologyRuntime });
@@ -140,5 +219,19 @@ describe('FLASH parser hardening regression', function() {
       unwrappedResult.address[0]._line[0].extension[0].valueString,
       unwrappedResult.address[0].line[0]
     );
+  });
+
+  it('should evaluate the unwrapped and parenthesized wildcard variable assignments to the same Patient output', async function() {
+    const unwrapped = await fumifier(issue84Expression, { navigator, terminologyRuntime });
+    const wrapped = await fumifier(issue84ParenthesizedControlExpression, { navigator, terminologyRuntime });
+
+    const unwrappedResult = await unwrapped.evaluate({});
+    const wrappedResult = await wrapped.evaluate({});
+
+    assert.deepEqual(unwrappedResult, wrappedResult);
+    assert.equal(unwrappedResult.resourceType, 'Patient');
+    assert(Array.isArray(unwrappedResult.identifier), 'Expected an identifier array in the evaluation result');
+    assert.equal(unwrappedResult.identifier.length, 1);
+    assert.equal(unwrappedResult.identifier[0].value, 'b');
   });
 });


### PR DESCRIPTION
## Summary

Resolves #84, where a bare wildcard variable assignment inside a FLASH block, such as `$value := *;`, was parsed as an empty FLASH rule and failed with `F1024`.

The parser now treats a bare `*` as a wildcard value expression in the same narrow RHS contexts where FLASH already expects a value expression. This makes the unwrapped form behave the same as the existing parenthesized workaround `$value := (*);`.

## What Changed

- Renamed the FLASH parser context flag from inline-expression scope to value-expression scope.
- Reused that same value-expression context while parsing the RHS of `:=` inside indent-aware FLASH parsing.
- Kept the context lifetime tightly scoped with `try/finally` so `*` still means "start of a FLASH rule" at rule boundaries.
- Added focused regression coverage for:
  - parse success for `$value := *;`
  - recover-mode success without attached errors
  - AST shape for the wildcard RHS
  - validation success
  - runtime equivalence with `$value := (*);`
  - malformed-rule guardrails for both `F1022` and `F1024`

## Scope and Safety

- No public API changes.
- No intended AST schema changes.
- No broader FLASH grammar changes.
- Existing malformed-rule behavior remains protected for standalone empty `*` rules and malformed double-star rules.

## Validation

- `npx mocha test/flash-parser-hardening.test.js --timeout=20000`
- `npx mocha test/parser-recovery.test.js --timeout=20000`

Both suites passed after the parser change.