### PR TITLE
Fix/HTTP Error Redaction

### DIFF
--- a/draft-release-notes-issue-89-http-error-redaction.md
+++ b/draft-release-notes-issue-89-http-error-redaction.md
@@ -1,0 +1,9 @@
+# Draft Release Notes: Issue 89 HTTP Error Redaction
+
+`fumifier` now prevents raw nested HTTP/client errors from being serialized into verbose diagnostics and wrapped FHIR-related runtime errors.
+
+This improves security and privacy behavior by removing accidental exposure of auth config, authorization headers, and other nested request details while preserving safe diagnostic fields such as error code, message, HTTP status, and safe request metadata when available.
+
+This is a bug-fix level change for the package. The public verbose contract was already intended to surface sanitized diagnostics rather than raw client internals.
+
+Consumers that were reading serialized `sourceError` payloads should switch to the stable safe fields exposed on diagnostics and wrapped errors (`code`, `message`, `sourceMessage`, `status`, `request`, and `operationOutcome` where present).

--- a/draft-release-notes-issue-89-http-error-redaction.md
+++ b/draft-release-notes-issue-89-http-error-redaction.md
@@ -1,9 +1,9 @@
 # Draft Release Notes: Issue 89 HTTP Error Redaction
 
-`fumifier` now prevents raw nested HTTP/client errors from being serialized into verbose diagnostics and wrapped FHIR-related runtime errors.
+`fumifier` now prevents raw nested HTTP/client errors from being serialized into verbose diagnostics and wrapped runtime errors across the FHIR helper, `$useFhirServer`, `$eval`, and mapping-wrapper paths.
 
-This improves security and privacy behavior by removing accidental exposure of auth config, authorization headers, and other nested request details while preserving safe diagnostic fields such as error code, message, HTTP status, and safe request metadata when available.
+This improves security and privacy behavior by removing accidental exposure of auth config, authorization headers, and other nested request details while preserving safe diagnostic fields such as error code, message, source message, HTTP status, and safe request metadata when available.
 
-This is a bug-fix level change for the package. The public verbose contract was already intended to surface sanitized diagnostics rather than raw client internals.
+This is a bug-fix level change for the package. The public verbose contract was already intended to surface sanitized diagnostics rather than raw client internals, and normalized 404 handling now avoids malformed “resource not found” diagnostics when a search-style failure has no concrete resource id.
 
-Consumers that were reading serialized `sourceError` payloads should switch to the stable safe fields exposed on diagnostics and wrapped errors (`code`, `message`, `sourceMessage`, `status`, `request`, and `operationOutcome` where present).
+Consumers that were reading serialized nested error payloads such as `sourceError`, `error`, or `cause` should switch to the stable safe fields exposed on diagnostics and wrapped errors (`code`, `message`, `sourceMessage`, `sourceErrorCode`, `status`, `request`, and `operationOutcome` where present).

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,13 @@
       "version": "2.3.1",
       "license": "AGPL-3.0",
       "dependencies": {
-        "lru-cache": "^11.3.6"
+        "lru-cache": "^11.5.1"
       },
       "devDependencies": {
         "@outburn/structure-navigator": "^1.9.5",
         "@outburn/types": "^0.2.0",
         "@types/json5": "^0.0.30",
-        "@types/node": "^25.8.0",
+        "@types/node": "^25.9.3",
         "@types/range-parser": "^1.2.7",
         "@types/yargs-parser": "^21.0.3",
         "c8": "^10.1.3",
@@ -27,9 +27,9 @@
         "fhir-package-explorer": "^1.9.4",
         "fhir-snapshot-generator": "^2.3.1",
         "fhir-terminology-runtime": "^1.3.0",
-        "fsh-sushi": "^3.19.0",
+        "fsh-sushi": "^3.20.0",
         "globals": "^17.6.0",
-        "mocha": "^11.7.5",
+        "mocha": "^11.7.6",
         "mocha-lcov-reporter": "^1.3.0",
         "node-fetch": "^3.3.2",
         "rimraf": "^6.1.3",
@@ -44,7 +44,7 @@
       "peerDependencies": {
         "@outburn/fhir-client": "^1.5.0",
         "@outburn/structure-navigator": "^1.9.5",
-        "@outburn/types": "^0.1.0 || ^0.2.0",
+        "@outburn/types": "^0.2.0",
         "fhir-package-explorer": "^1.9.4",
         "fhir-snapshot-generator": "^2.3.1",
         "fhir-terminology-runtime": "^1.3.0"
@@ -899,9 +899,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
-      "integrity": "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.0.tgz",
+      "integrity": "sha512-IPIQ55ythEHkfEd9jMEi32OQ7SxURsGA43JI22lj01OLZNt2NUbJX8YUHxkVWyQ6daHPNn0truF5nSj3DQp6YQ==",
       "cpu": [
         "arm"
       ],
@@ -913,9 +913,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz",
-      "integrity": "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.0.tgz",
+      "integrity": "sha512-M6s9cr10MibETyo8JsOkq+Lo1+lU6hcvb1MApnUql5qte/5hMEgzlN8/ReIKNfRV8rrqX50W1BX9zoUhC192RA==",
       "cpu": [
         "arm64"
       ],
@@ -927,9 +927,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
-      "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.0.tgz",
+      "integrity": "sha512-BqCoMoIbn0keKys+dEAdBa70EtOwV1bEsQCUgU9FdiZmmMge/Zk7LlkYGqbrdHR+Frnt0E1FOanly+rlwvvQzw==",
       "cpu": [
         "arm64"
       ],
@@ -941,9 +941,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz",
-      "integrity": "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.0.tgz",
+      "integrity": "sha512-SIMzST3VFNXDAbeIWDWiFCNM5qncUBDWaEV7NfE7oZbDt2mgfW4MvbKdbYiGOLoM32gbTv608UMd0XktEYSD7w==",
       "cpu": [
         "x64"
       ],
@@ -955,9 +955,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz",
-      "integrity": "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.0.tgz",
+      "integrity": "sha512-ezjfSQMP7ArdUsbBwbQIfwAlhE84I2iVnzQNCFSveqV42q+BmKlzVpf7mxv5EchLcoWU4y6/heFzVg1F+hodUQ==",
       "cpu": [
         "arm64"
       ],
@@ -969,9 +969,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz",
-      "integrity": "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.0.tgz",
+      "integrity": "sha512-9+qTWGW9AZRhnUgwtTwzNwcPlL87ngkeN0LA+q1bADvmY9aNvWaF2TFW8BZgnQPYxpDI7+rMVLivcd4V737TAQ==",
       "cpu": [
         "x64"
       ],
@@ -983,9 +983,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz",
-      "integrity": "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.0.tgz",
+      "integrity": "sha512-T1dMEQhXA/jkJ/jyMIw9IovK8bSUq7A8kLIlvZTb/6YIVsp2zLavr4F3oyllHWo7eIVJRyE5n3tUjQJEbE1IuQ==",
       "cpu": [
         "arm"
       ],
@@ -1000,9 +1000,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz",
-      "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.0.tgz",
+      "integrity": "sha512-2as0LgT7qQpyceQq6VUJYnumUMUrgGQCWIiDIN9DE0/tglsk6o66uCB4f3djRawAltvfCNLyZZrsqbPA6inCsA==",
       "cpu": [
         "arm"
       ],
@@ -1017,9 +1017,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz",
-      "integrity": "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.0.tgz",
+      "integrity": "sha512-bVURMg+6eNN9C/yc0aVjooZcwTTtYF4YW3xta5pP0//r3o1V8gXEHXWCndj47w/HhwsFroZrFhR+6uQP5T0n0g==",
       "cpu": [
         "arm64"
       ],
@@ -1034,9 +1034,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz",
-      "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.0.tgz",
+      "integrity": "sha512-Ful8pM/2yYI83PViWdFdpZhdI8HJ5qsXANe5atypbHDf+KIBBDsZsbyy8hbXnULVvW9NsTh5DHwbcBftyLTfiw==",
       "cpu": [
         "arm64"
       ],
@@ -1051,9 +1051,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
-      "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.0.tgz",
+      "integrity": "sha512-9Gp/DgrkzfUBmNPVTyPTvay+4xEP7M/clXpj3efXBcm6uTIVIgDg4rqUpqKXvLEuFRVuEpSAOkhgNeecvaZ4Cg==",
       "cpu": [
         "loong64"
       ],
@@ -1068,9 +1068,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
-      "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.0.tgz",
+      "integrity": "sha512-m9tsJz54LUXkSYM8+8PG81B9IKK5r+2T0clMq4QrS16xFosufU7firBDAZEsDheDs7wTlP7h3++S7lMsU955HA==",
       "cpu": [
         "loong64"
       ],
@@ -1085,9 +1085,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
-      "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.0.tgz",
+      "integrity": "sha512-3UvJ5PNVU16aJf6M3tFI24pWzAl2/ynfbyRN3ICyQajK1lSkrnVYNnLz3v04J32qKa0FczJc22zeToc0lr2A3w==",
       "cpu": [
         "ppc64"
       ],
@@ -1102,9 +1102,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
-      "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.0.tgz",
+      "integrity": "sha512-vRWUAbYLGHBZS6Q8Msb2sfnf1fvJf+47t8l/TwOerM2qArzy+IeNMTHrYLHXh95h8MoatPHI5hhSZNs+mGXKPg==",
       "cpu": [
         "ppc64"
       ],
@@ -1119,9 +1119,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
-      "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.0.tgz",
+      "integrity": "sha512-c00T5SYENHAt86cfW47URaP3Us5vLC/4QO7GYud1G5VNRffCwwCuBspwqYrriuJB+5m0WFzClCn9wed0FBjKvg==",
       "cpu": [
         "riscv64"
       ],
@@ -1136,9 +1136,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
-      "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.0.tgz",
+      "integrity": "sha512-krrCDilhXOwFkSkO3Wm9I/f9H0L92XHHwy2fwxjukxIbh0dem8gZqOW5Y8BsHrpJv5qwlRBV+Wl4ZFyRWhUpwg==",
       "cpu": [
         "riscv64"
       ],
@@ -1153,9 +1153,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz",
-      "integrity": "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.0.tgz",
+      "integrity": "sha512-7pfYFSTc4/rUC/FtAI0Qp6QthDBCIi6/AuP1xYqFk5vanI6KnL5dWKP60OM/05LOsbwTmIcvr6eXC4CJuJ75IA==",
       "cpu": [
         "s390x"
       ],
@@ -1170,9 +1170,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
-      "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.0.tgz",
+      "integrity": "sha512-7SDIalKeIpG0Ifogbbdn58HmSotYMlf23K3dCJEmiVd9Fg36Vmni82iPQec27N3wY4Bvbxftkxz6vSx9OcouTg==",
       "cpu": [
         "x64"
       ],
@@ -1187,9 +1187,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz",
-      "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.0.tgz",
+      "integrity": "sha512-eRZevouTH2i1HeAVLqJuLnt256krQkGY0TN6WsTmsIhuzbh457HuWDMakKwmi0Cjadux983CoSr8Lim2QhUIFw==",
       "cpu": [
         "x64"
       ],
@@ -1204,9 +1204,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz",
-      "integrity": "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.0.tgz",
+      "integrity": "sha512-3oVS7FLGa4U1qcvao9ylGxrjXZyUQqR8UwxEcnUEyPX53O/C/mKDZegNXTdHCP+h3e6ta/f1EN38Yif1mmZHYg==",
       "cpu": [
         "x64"
       ],
@@ -1218,9 +1218,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz",
-      "integrity": "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.0.tgz",
+      "integrity": "sha512-yTB9TgfWj5wHe5QgktAgXTLLot1gvEjl1NiPPAUiCs4oPrIWFl5V4nC3GrkNdj9LaAU4s94nVrGbGOCqUpyWsg==",
       "cpu": [
         "arm64"
       ],
@@ -1232,9 +1232,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz",
-      "integrity": "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.0.tgz",
+      "integrity": "sha512-5LOhoaesY3doG1c+ac/2JtgREpKoJr5bUHH8tKY0V8di7+uSV6BwLs2PlR0/yzefGOkR+wE7ZolZphHCsyG5Rw==",
       "cpu": [
         "arm64"
       ],
@@ -1246,9 +1246,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz",
-      "integrity": "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.0.tgz",
+      "integrity": "sha512-yYkWHhmbhRTWTnWos5HC4GcPQfjlzzCNbM9e/+GXrLuaBXYA3qSDR9f0Vgufd5S8yX81U8jPKp7ZnAjZFMtRnw==",
       "cpu": [
         "ia32"
       ],
@@ -1260,9 +1260,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz",
-      "integrity": "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.0.tgz",
+      "integrity": "sha512-SoTb6lPg25xZlA2ibwQ++ahCCnH+FP0qmEuafMJ4gznZKOlXioKEAeJLgCrqjM98ACziXM9V1amFjICVL4IFoA==",
       "cpu": [
         "x64"
       ],
@@ -1274,9 +1274,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
-      "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.0.tgz",
+      "integrity": "sha512-5L+T1fMX4RIEBoZzT0+sQ0PhTS36NULFmMXtl1TZo44TMAROIMHbZufSOjVWt/Y622BtxgxtaNOokbTDvfsrZA==",
       "cpu": [
         "x64"
       ],
@@ -1340,9 +1340,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.8.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.8.0.tgz",
-      "integrity": "sha512-TCFSk8IZh+iLX1xtksoBVtdmgL+1IX0fC9BeU4QqFSuNdN/K+HUlhqOzEmSYYpZUVsLYcPqc9KX+60iDuninSQ==",
+      "version": "25.9.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.3.tgz",
+      "integrity": "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1371,9 +1371,9 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.59.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.3.tgz",
-      "integrity": "sha512-ePFoH0g4ludssdRFqqDxQePCxU4WQyRa9+XVwjm7yLn0FKhMeoetC+qBEEI1Eyb1pGSDveTIT09Bvw2WhlGayg==",
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.61.0.tgz",
+      "integrity": "sha512-9QTQpZ5Iin4CdIodfbDQFSeiSJKidgYJYug1P9CC2xWgUTvlmixViqDZNciMjwLBZyJnG4tGmPl97rVAFb1AJg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1392,9 +1392,9 @@
       "license": "MIT"
     },
     "node_modules/acorn": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
-      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -1602,9 +1602,9 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
-      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.17.0.tgz",
+      "integrity": "sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1664,9 +1664,9 @@
       "license": "MIT"
     },
     "node_modules/bare-events": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.3.tgz",
-      "integrity": "sha512-HdUm8EMQBLaJvGUdidNNbqpA1kYkwNcb+MYxkxCLAPJGQzlv9J0C24h8V65Z4c5GLd/JEALDvpFCQgpLJqc0zw==",
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.1.tgz",
+      "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
       "dev": true,
       "license": "Apache-2.0",
       "peerDependencies": {
@@ -1679,9 +1679,9 @@
       }
     },
     "node_modules/bare-fs": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.1.tgz",
-      "integrity": "sha512-WDRsyVN52eAx/lBamKD6uyw8H4228h/x0sGGGegOamM2cd7Pag88GfMQalobXI+HaEUxpCkbKQUDOQqt9wawRw==",
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.2.tgz",
+      "integrity": "sha512-aTvMFUWkBmjzKtEQMDGGDNF8bkfpD5N1b/FCwt7A3wrU4t1o/e/85Wzkluh6JlODCjqVESYCkQCdTXqZ9G7VFg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1714,9 +1714,9 @@
       }
     },
     "node_modules/bare-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
-      "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.1.tgz",
+      "integrity": "sha512-ghj2DSK/2e99a1anTVPCV4m4YIYtrbXhfM7V3D7XZLOTsybnYyaJloymGqssQc8l/or0UoDyRtNQkmkEF/ysgQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1724,12 +1724,13 @@
       }
     },
     "node_modules/bare-stream": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.1.tgz",
-      "integrity": "sha512-Vp0cnjYyrEC4whYTymQ+YZi6pBpfiICZO3cfRG8sy67ZNWe951urv1x4eW1BKNngw3U+3fPYb5JQvHbCtxH7Ow==",
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.3.tgz",
+      "integrity": "sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
+        "b4a": "^1.8.1",
         "streamx": "^2.25.0",
         "teex": "^1.0.1"
       },
@@ -1751,9 +1752,9 @@
       }
     },
     "node_modules/bare-url": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.3.tgz",
-      "integrity": "sha512-Kccpc7ACfXaxfeInfqKcZtW4pT5YBn1mesc4sCsun6sRwtbJ4h+sNOaksUpYEJUKfN65YWC6Bw2OJEFiKxq8nQ==",
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.5.tgz",
+      "integrity": "sha512-K+y9xF1tN+CdPu4qWwr0QiK1Al07eFPGYK5M2pDXcmHdMdgC/tT/bpmMe1hrmRHaidKLkXrC+cRNYf3XVDUhSQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1797,9 +1798,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2517,9 +2518,9 @@
       }
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3204,17 +3205,17 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -3271,9 +3272,9 @@
       }
     },
     "node_modules/fsh-sushi": {
-      "version": "3.19.0",
-      "resolved": "https://registry.npmjs.org/fsh-sushi/-/fsh-sushi-3.19.0.tgz",
-      "integrity": "sha512-ImGmQHh4wsbCmvC7LB9Yu8q5Tub/tLWGun1nUB0P/jmioGqnIgtb2rVOxntAy5NHnQ4lAxCUR6CSimQroXWheQ==",
+      "version": "3.20.0",
+      "resolved": "https://registry.npmjs.org/fsh-sushi/-/fsh-sushi-3.20.0.tgz",
+      "integrity": "sha512-fW5H+XANg75WoU2eikmDx62Cf8ow6whxy+3RX7SoRES4HxnCeQ6MMq3BlS5VLrKM010l6Tj8fmuJ0nwPETtC+Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3447,9 +3448,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3545,9 +3546,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
-      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3907,10 +3908,20 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -4110,9 +4121,9 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "11.3.6",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
-      "integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -4277,9 +4288,9 @@
       }
     },
     "node_modules/mocha": {
-      "version": "11.7.5",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.5.tgz",
-      "integrity": "sha512-mTT6RgopEYABzXWFx+GcJ+ZQ32kp4fMf0xvpZIIfSq9Z8lC/++MtcCnQ9t5FP2veYEP95FIYSvW+U9fV4xrlig==",
+      "version": "11.7.6",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.6.tgz",
+      "integrity": "sha512-nS9xOGbw2I3cjCpxwZAEJ9xK9lmJ08vEkQvLtz4du9ZrF9UrjRpeJGiIgl2Z+Qs++pmB4ecDe48Fwsh+j+j7xA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4324,9 +4335,9 @@
       }
     },
     "node_modules/mocha/node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4476,9 +4487,9 @@
       }
     },
     "node_modules/object-deep-merge": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/object-deep-merge/-/object-deep-merge-2.0.0.tgz",
-      "integrity": "sha512-3DC3UMpeffLTHiuXSy/UG4NOIYTLlY9u3V82+djSCLYClWobZiS4ivYzpIUWrRY/nfsJ8cWsKyG3QfyLePmhvg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/object-deep-merge/-/object-deep-merge-2.0.1.tgz",
+      "integrity": "sha512-aKttDKcU3pyZqKcCkDhsMn70WmZFG2JGDQLP9EcLyTSIFQRCPWLAmBZRLJnrVUrhPG1jETEEbfdgbNtJf1LyMg==",
       "dev": true,
       "license": "MIT"
     },
@@ -5127,13 +5138,13 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
-      "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.0.tgz",
+      "integrity": "sha512-nc72Wgq62I7rtDV4izT5/aaS0zxy3kttkinf9586ApknY3jZO9NYsmtc24fUckA0X7Q2v+ML4a15pdUlV5V/jA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/estree": "1.0.8"
+        "@types/estree": "1.0.9"
       },
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -5143,40 +5154,33 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.60.4",
-        "@rollup/rollup-android-arm64": "4.60.4",
-        "@rollup/rollup-darwin-arm64": "4.60.4",
-        "@rollup/rollup-darwin-x64": "4.60.4",
-        "@rollup/rollup-freebsd-arm64": "4.60.4",
-        "@rollup/rollup-freebsd-x64": "4.60.4",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.60.4",
-        "@rollup/rollup-linux-arm-musleabihf": "4.60.4",
-        "@rollup/rollup-linux-arm64-gnu": "4.60.4",
-        "@rollup/rollup-linux-arm64-musl": "4.60.4",
-        "@rollup/rollup-linux-loong64-gnu": "4.60.4",
-        "@rollup/rollup-linux-loong64-musl": "4.60.4",
-        "@rollup/rollup-linux-ppc64-gnu": "4.60.4",
-        "@rollup/rollup-linux-ppc64-musl": "4.60.4",
-        "@rollup/rollup-linux-riscv64-gnu": "4.60.4",
-        "@rollup/rollup-linux-riscv64-musl": "4.60.4",
-        "@rollup/rollup-linux-s390x-gnu": "4.60.4",
-        "@rollup/rollup-linux-x64-gnu": "4.60.4",
-        "@rollup/rollup-linux-x64-musl": "4.60.4",
-        "@rollup/rollup-openbsd-x64": "4.60.4",
-        "@rollup/rollup-openharmony-arm64": "4.60.4",
-        "@rollup/rollup-win32-arm64-msvc": "4.60.4",
-        "@rollup/rollup-win32-ia32-msvc": "4.60.4",
-        "@rollup/rollup-win32-x64-gnu": "4.60.4",
-        "@rollup/rollup-win32-x64-msvc": "4.60.4",
+        "@rollup/rollup-android-arm-eabi": "4.62.0",
+        "@rollup/rollup-android-arm64": "4.62.0",
+        "@rollup/rollup-darwin-arm64": "4.62.0",
+        "@rollup/rollup-darwin-x64": "4.62.0",
+        "@rollup/rollup-freebsd-arm64": "4.62.0",
+        "@rollup/rollup-freebsd-x64": "4.62.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.0",
+        "@rollup/rollup-linux-arm64-musl": "4.62.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.0",
+        "@rollup/rollup-linux-loong64-musl": "4.62.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.0",
+        "@rollup/rollup-linux-x64-gnu": "4.62.0",
+        "@rollup/rollup-linux-x64-musl": "4.62.0",
+        "@rollup/rollup-openbsd-x64": "4.62.0",
+        "@rollup/rollup-openharmony-arm64": "4.62.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.0",
+        "@rollup/rollup-win32-x64-gnu": "4.62.0",
+        "@rollup/rollup-win32-x64-msvc": "4.62.0",
         "fsevents": "~2.3.2"
       }
-    },
-    "node_modules/rollup/node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
@@ -5230,9 +5234,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -5464,9 +5468,9 @@
       }
     },
     "node_modules/streamx": {
-      "version": "2.25.0",
-      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.25.0.tgz",
-      "integrity": "sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==",
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.28.0.tgz",
+      "integrity": "sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5659,9 +5663,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.15",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.15.tgz",
-      "integrity": "sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==",
+      "version": "7.5.16",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
+      "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -5882,9 +5886,9 @@
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -90,13 +90,13 @@
     "LICENSES/**"
   ],
   "dependencies": {
-    "lru-cache": "^11.3.6"
+    "lru-cache": "^11.5.1"
   },
   "devDependencies": {
     "@outburn/structure-navigator": "^1.9.5",
     "@outburn/types": "^0.2.0",
     "@types/json5": "^0.0.30",
-    "@types/node": "^25.8.0",
+    "@types/node": "^25.9.3",
     "@types/range-parser": "^1.2.7",
     "@types/yargs-parser": "^21.0.3",
     "c8": "^10.1.3",
@@ -108,9 +108,9 @@
     "fhir-package-explorer": "^1.9.4",
     "fhir-snapshot-generator": "^2.3.1",
     "fhir-terminology-runtime": "^1.3.0",
-    "fsh-sushi": "^3.19.0",
+    "fsh-sushi": "^3.20.0",
     "globals": "^17.6.0",
-    "mocha": "^11.7.5",
+    "mocha": "^11.7.6",
     "mocha-lcov-reporter": "^1.3.0",
     "node-fetch": "^3.3.2",
     "rimraf": "^6.1.3",
@@ -125,7 +125,7 @@
   "peerDependencies": {
     "@outburn/fhir-client": "^1.5.0",
     "@outburn/structure-navigator": "^1.9.5",
-    "@outburn/types": "^0.1.0 || ^0.2.0",
+    "@outburn/types": "^0.2.0",
     "fhir-package-explorer": "^1.9.4",
     "fhir-snapshot-generator": "^2.3.1",
     "fhir-terminology-runtime": "^1.3.0"

--- a/src/fumifier.js
+++ b/src/fumifier.js
@@ -88,9 +88,6 @@ class FumifierError extends Error {
     /** @type {any} [flashDiagnostics] FLASH diagnostics collected during evaluation */
     this.flashDiagnostics = properties.flashDiagnostics;
 
-    /** @type {any} [sourceError] Source error for wrapped errors */
-    this.sourceError = properties.sourceError;
-
     /** @type {string} [sourceErrorCode] Source error code for wrapped errors */
     this.sourceErrorCode = properties.sourceErrorCode;
 
@@ -103,6 +100,19 @@ class FumifierError extends Error {
         this[key] = properties[key];
       }
     });
+
+    if (properties.sourceError !== undefined) {
+      try {
+        Object.defineProperty(this, 'sourceError', {
+          value: properties.sourceError,
+          enumerable: false,
+          configurable: true,
+          writable: true
+        });
+      } catch (_) {
+        /* ignore */
+      }
+    }
 
     // Ensure we have a stack trace
     if (Error.captureStackTrace) {
@@ -1380,15 +1390,14 @@ var fumifier = (function() {
     try {
       re = new RegExp(pattern, flags);
     } catch (err) {
-      throw new FumifierError('S0303', undefined, {
+      throw attachSourceErrorMetadata(new FumifierError('S0303', undefined, {
         position: expr.position,
         start: expr.start,
         line: expr.line,
         value: `/${pattern}/${flags}`,
         sourceMessage: err.message,
-        sourceError: err,
         stack: err.stack || (new Error()).stack
-      });
+      }), err);
     }
 
     var closure = function(str, fromIndex) {
@@ -2281,12 +2290,11 @@ var fumifier = (function() {
     } catch(err) {
       // error evaluating the expression passed to $eval
       populateMessage(err, this.environment);
-      throw {
+      throw attachSourceErrorMetadata({
         stack: (new Error()).stack,
         code: "D3121",
-        value:err.message,
-        error: err
-      };
+        value: err.message
+      }, err);
     }
   }
 
@@ -2314,14 +2322,11 @@ var fumifier = (function() {
       } catch(sourceError) {
         populateMessage(sourceError, this.environment);
         // Cache error - throw specific error
-        throw {
+        throw attachSourceErrorMetadata({
           code: "F3006",
-          sourceErrorCode: sourceError.code || 'Unknown',
           value: mappingKey,
-          sourceMessage: sourceError.message || sourceError,
-          sourceError,
           stack: (new Error()).stack
-        };
+        }, sourceError);
       }
 
       if (typeof expr === 'undefined') {
@@ -2365,15 +2370,14 @@ var fumifier = (function() {
         ast = await parseAndCacheExpression(expr, false, navigator, terminologyRuntime, astCacheImpl, compiledFhirRegex, "F3002");
       } catch(parseError) {
         // error parsing the mapping expression - customize error format for mapping context
-        populateMessage(parseError.error || parseError, this.environment);
-        throw {
+        const nestedParseError = parseError.error || parseError;
+        populateMessage(nestedParseError, this.environment);
+        throw attachSourceErrorMetadata({
           code: "F3002",
-          sourceErrorCode: (parseError.error && parseError.error.code) || parseError.code || 'Unknown',
           value: mappingKey,
-          sourceMessage: (parseError.error && parseError.error.message) || parseError.message || parseError.value || parseError,
-          sourceError: parseError.error || parseError,
+          sourceMessage: parseError.message || parseError.value || nestedParseError.message || String(nestedParseError),
           stack: (new Error()).stack
-        };
+        }, nestedParseError);
       }
 
       try {
@@ -2385,14 +2389,11 @@ var fumifier = (function() {
       } catch(sourceError) {
         // error evaluating the mapping expression
         populateMessage(sourceError, this.environment);
-        throw {
+        throw attachSourceErrorMetadata({
           code: 'F3001',
-          sourceErrorCode: sourceError.code || 'Unknown',
           value: mappingKey,
-          sourceMessage: sourceError.message || sourceError,
-          sourceError,
           stack: (new Error()).stack
-        };
+        }, sourceError);
       }
     };
   }

--- a/src/fumifier.js
+++ b/src/fumifier.js
@@ -33,7 +33,7 @@ import { populateMessage } from './utils/errorCodes.js';
 import defineFunction from './utils/defineFunction.js';
 import registerNativeFn from './utils/registerNativeFn.js';
 import createFlashEvaluator from './flashEvaluator.js';
-import { createDefaultLogger, SYM, decide, push, thresholds, severityFromCode, LEVELS } from './utils/diagnostics.js';
+import { createDefaultLogger, SYM, decide, push, thresholds, severityFromCode, LEVELS, attachSourceErrorMetadata } from './utils/diagnostics.js';
 import createFhirClientWrappers from './utils/fhirClientWrappers.js';
 import createTerminologyWrappers from './utils/terminologyWrappers.js';
 
@@ -2551,12 +2551,11 @@ var fumifier = (function() {
           throw err;
         }
 
-        throw new FumifierError('D3201', undefined, {
+        throw attachSourceErrorMetadata(new FumifierError('D3201', undefined, {
           target,
           sourceMessage: err?.message || String(err),
-          sourceError: err,
           stack: err?.stack || (new Error()).stack
-        });
+        }), err);
       }
 
       if (typeof config === 'undefined') {

--- a/src/utils/diagnostics.js
+++ b/src/utils/diagnostics.js
@@ -117,6 +117,139 @@ export function getLogger(env) {
 }
 
 /**
+ * Determine whether a value is a non-null object.
+ * @param {*} value - Value to inspect.
+ * @returns {boolean} True when the value can carry object properties.
+ */
+function isObjectLike(value) {
+  return value !== null && typeof value === 'object';
+}
+
+/**
+ * Check whether a value is a FHIR OperationOutcome resource.
+ * @param {*} value - Candidate value.
+ * @returns {boolean} True when the value is an OperationOutcome-like object.
+ */
+function isOperationOutcome(value) {
+  return isObjectLike(value) && value.resourceType === 'OperationOutcome';
+}
+
+/**
+ * Copy only safe request metadata from an error request descriptor.
+ * @param {*} request - Request metadata attached to an error.
+ * @returns {object|undefined} Sanitized request summary when available.
+ */
+function sanitizeRequest(request) {
+  if (!isObjectLike(request)) return undefined;
+
+  const sanitized = {};
+  if (typeof request.method === 'string') sanitized.method = request.method;
+  if (typeof request.url === 'string') sanitized.url = request.url;
+  if (typeof request.resourceType === 'string') sanitized.resourceType = request.resourceType;
+  if (typeof request.id === 'string') sanitized.id = request.id;
+
+  return Object.keys(sanitized).length > 0 ? sanitized : undefined;
+}
+
+/**
+ * Build a safe summary of a nested source error for diagnostic exposure.
+ * @param {*} sourceError - Original nested error or error-like value.
+ * @returns {object|undefined} Safe summary fields that may be exposed publicly.
+ */
+function summarizeSourceError(sourceError) {
+  if (!isObjectLike(sourceError)) {
+    if (typeof sourceError === 'undefined') return undefined;
+    return { message: String(sourceError) };
+  }
+
+  const summary = {};
+
+  if (typeof sourceError.name === 'string') summary.name = sourceError.name;
+  if (typeof sourceError.code === 'string') summary.code = sourceError.code;
+  if (typeof sourceError.message === 'string') summary.message = sourceError.message;
+
+  let status;
+  if (typeof sourceError.status === 'number') {
+    status = sourceError.status;
+  } else if (typeof sourceError.response?.status === 'number') {
+    status = sourceError.response.status;
+  }
+  if (typeof status === 'number') summary.status = status;
+
+  const request = sanitizeRequest(sourceError.request);
+  if (request) summary.request = request;
+
+  let operationOutcome;
+  if (isOperationOutcome(sourceError.operationOutcome)) {
+    operationOutcome = sourceError.operationOutcome;
+  } else if (isOperationOutcome(sourceError.response?.data)) {
+    operationOutcome = sourceError.response.data;
+  }
+  if (operationOutcome) summary.operationOutcome = operationOutcome;
+
+  return Object.keys(summary).length > 0 ? summary : undefined;
+}
+
+/**
+ * Attach safe source-error metadata while keeping the raw cause non-enumerable.
+ * @param {object} target - Error or diagnostic object being enriched.
+ * @param {*} sourceError - Original nested error value.
+ * @returns {object} The same target object after enrichment.
+ */
+export function attachSourceErrorMetadata(target, sourceError) {
+  if (!isObjectLike(target) || typeof sourceError === 'undefined') return target;
+
+  const summary = summarizeSourceError(sourceError);
+  if (summary) {
+    if (typeof target.sourceMessage === 'undefined' && typeof summary.message === 'string') {
+      target.sourceMessage = summary.message;
+    }
+    if (typeof target.sourceErrorCode === 'undefined' && typeof summary.code === 'string') {
+      target.sourceErrorCode = summary.code;
+    }
+    if (typeof target.status === 'undefined' && typeof summary.status === 'number') {
+      target.status = summary.status;
+    }
+    if (typeof target.request === 'undefined' && summary.request) {
+      target.request = summary.request;
+    }
+    if (typeof target.operationOutcome === 'undefined' && summary.operationOutcome) {
+      target.operationOutcome = summary.operationOutcome;
+    }
+  } else if (typeof target.sourceMessage === 'undefined') {
+    target.sourceMessage = String(sourceError);
+  }
+
+  try {
+    Object.defineProperty(target, 'sourceError', {
+      value: sourceError,
+      enumerable: false,
+      configurable: true,
+      writable: true
+    });
+  } catch (_) {
+    /* ignore */
+  }
+
+  return target;
+}
+
+/**
+ * Remove non-public fields from a diagnostic entry before collection.
+ * @param {*} entry - Diagnostic entry or error-like value.
+ * @returns {object} Sanitized diagnostic object safe for verbose reporting.
+ */
+export function sanitizeDiagnosticEntry(entry) {
+  const rest = { ...(entry || {}) };
+  if (entry instanceof Error || (typeof entry?.message === 'string' && !Object.prototype.hasOwnProperty.call(rest, 'message'))) {
+    rest.message = entry.message;
+  }
+  if (Object.prototype.hasOwnProperty.call(rest, 'stack')) delete rest.stack;
+  if (Object.prototype.hasOwnProperty.call(rest, 'sourceError')) delete rest.sourceError;
+  return rest;
+}
+
+/**
  * Decide actions under current thresholds for a given error code.
  * @param {string} code Error code like F5320.
  * @param {{lookup:function(*):*}} env Execution environment.
@@ -158,12 +291,8 @@ export function push(env, entry) {
     bucket = 'debug'; // notice, info, debug → informational
   }
 
-  // sanitize entry: remove stack from collected diagnostics
-  const rest = { ...(entry || {}) };
-  if (entry instanceof Error || (typeof entry?.message === 'string' && !Object.prototype.hasOwnProperty.call(rest, 'message'))) {
-    rest.message = entry.message;
-  }
-  if (Object.prototype.hasOwnProperty.call(rest, 'stack')) delete rest.stack;
+  // sanitize entry before collecting diagnostics
+  const rest = sanitizeDiagnosticEntry(entry);
 
   // dedupe: ensure we don't collect identical diagnostics multiple times
   const seen = (() => {

--- a/src/utils/diagnostics.js
+++ b/src/utils/diagnostics.js
@@ -191,12 +191,12 @@ function summarizeSourceError(sourceError) {
 }
 
 /**
- * Attach safe source-error metadata while keeping the raw cause non-enumerable.
+ * Copy safe source-error metadata onto a target without retaining the raw nested error.
  * @param {object} target - Error or diagnostic object being enriched.
- * @param {*} sourceError - Original nested error value.
+ * @param {*} sourceError - Original nested error or error-like value.
  * @returns {object} The same target object after enrichment.
  */
-export function attachSourceErrorMetadata(target, sourceError) {
+function copySafeErrorMetadata(target, sourceError) {
   if (!isObjectLike(target) || typeof sourceError === 'undefined') return target;
 
   const summary = summarizeSourceError(sourceError);
@@ -220,6 +220,20 @@ export function attachSourceErrorMetadata(target, sourceError) {
     target.sourceMessage = String(sourceError);
   }
 
+  return target;
+}
+
+/**
+ * Attach safe source-error metadata while keeping the raw cause non-enumerable.
+ * @param {object} target - Error or diagnostic object being enriched.
+ * @param {*} sourceError - Original nested error value.
+ * @returns {object} The same target object after enrichment.
+ */
+export function attachSourceErrorMetadata(target, sourceError) {
+  if (!isObjectLike(target) || typeof sourceError === 'undefined') return target;
+
+  copySafeErrorMetadata(target, sourceError);
+
   try {
     Object.defineProperty(target, 'sourceError', {
       value: sourceError,
@@ -240,12 +254,24 @@ export function attachSourceErrorMetadata(target, sourceError) {
  * @returns {object} Sanitized diagnostic object safe for verbose reporting.
  */
 export function sanitizeDiagnosticEntry(entry) {
+  const source = isObjectLike(entry) ? entry : {};
   const rest = { ...(entry || {}) };
   if (entry instanceof Error || (typeof entry?.message === 'string' && !Object.prototype.hasOwnProperty.call(rest, 'message'))) {
     rest.message = entry.message;
   }
+  if (Object.prototype.hasOwnProperty.call(source, 'sourceError')) {
+    copySafeErrorMetadata(rest, source.sourceError);
+  }
+  if (Object.prototype.hasOwnProperty.call(source, 'error')) {
+    copySafeErrorMetadata(rest, source.error);
+  }
+  if (Object.prototype.hasOwnProperty.call(source, 'cause')) {
+    copySafeErrorMetadata(rest, source.cause);
+  }
   if (Object.prototype.hasOwnProperty.call(rest, 'stack')) delete rest.stack;
   if (Object.prototype.hasOwnProperty.call(rest, 'sourceError')) delete rest.sourceError;
+  if (Object.prototype.hasOwnProperty.call(rest, 'error')) delete rest.error;
+  if (Object.prototype.hasOwnProperty.call(rest, 'cause')) delete rest.cause;
   return rest;
 }
 

--- a/src/utils/fhirClientWrappers.js
+++ b/src/utils/fhirClientWrappers.js
@@ -17,6 +17,30 @@ import { attachSourceErrorMetadata } from './diagnostics.js';
  */
 function createFhirClientWrappers(getFhirClient) {
   /**
+   * Extract a concrete resource identity from a literal reference or normalized request metadata.
+   * @param {string} resourceTypeOrRef - Resource type or literal reference.
+   * @param {any} err - Error thrown by the FHIR client layer.
+   * @returns {{resourceType:string, resourceId:string}|undefined} Safe resource identity when available.
+   */
+  function getResourceIdentity(resourceTypeOrRef, err) {
+    if (typeof resourceTypeOrRef === 'string') {
+      const [resourceType, resourceId] = resourceTypeOrRef.split('/');
+      if (resourceType && resourceId) {
+        return { resourceType, resourceId };
+      }
+    }
+
+    if (typeof err?.request?.resourceType === 'string' && typeof err?.request?.id === 'string' && err.request.resourceType && err.request.id) {
+      return {
+        resourceType: err.request.resourceType,
+        resourceId: err.request.id
+      };
+    }
+
+    return undefined;
+  }
+
+  /**
    * Read an HTTP-like status from either normalized FHIR client errors or legacy Axios-shaped errors.
    * @param {any} err - Error thrown by the FHIR client layer.
    * @returns {number|undefined} HTTP status when available.
@@ -56,14 +80,15 @@ function createFhirClientWrappers(getFhirClient) {
   function handleFhirClientError(err, operationName, resourceTypeOrRef, params, environment) {
     // Check for 404 errors
     if (getErrorStatus(err) === 404) {
-      const ref = resourceTypeOrRef;
-      const [resourceType, resourceId] = ref.split('/');
-      return handleError(attachSourceErrorMetadata({
-        code: 'F5210',
-        resourceType,
-        resourceId,
-        stack: err.stack || (new Error()).stack
-      }, err), environment);
+      const identity = getResourceIdentity(resourceTypeOrRef, err);
+      if (identity) {
+        return handleError(attachSourceErrorMetadata({
+          code: 'F5210',
+          resourceType: identity.resourceType,
+          resourceId: identity.resourceId,
+          stack: err.stack || (new Error()).stack
+        }, err), environment);
+      }
     }
 
     // Check for "No resources found" errors

--- a/src/utils/fhirClientWrappers.js
+++ b/src/utils/fhirClientWrappers.js
@@ -7,6 +7,7 @@ License: See the LICENSE file included with this package for the terms that appl
 
 import createPolicy from './policy.js';
 import { populateMessage } from './errorCodes.js';
+import { attachSourceErrorMetadata } from './diagnostics.js';
 
 /**
  * Creates user-facing wrapper functions for FHIR client operations.
@@ -15,6 +16,15 @@ import { populateMessage } from './errorCodes.js';
  * @returns {Object} Object containing wrapper functions
  */
 function createFhirClientWrappers(getFhirClient) {
+  /**
+   * Read an HTTP-like status from either normalized FHIR client errors or legacy Axios-shaped errors.
+   * @param {any} err - Error thrown by the FHIR client layer.
+   * @returns {number|undefined} HTTP status when available.
+   */
+  function getErrorStatus(err) {
+    return typeof err?.status === 'number' ? err.status : err?.response?.status;
+  }
+
   /**
    * Helper to handle errors through policy system
    * Respects throwLevel to decide whether to throw or return undefined
@@ -45,55 +55,51 @@ function createFhirClientWrappers(getFhirClient) {
    */
   function handleFhirClientError(err, operationName, resourceTypeOrRef, params, environment) {
     // Check for 404 errors
-    if (err.response && err.response.status === 404) {
+    if (getErrorStatus(err) === 404) {
       const ref = resourceTypeOrRef;
       const [resourceType, resourceId] = ref.split('/');
-      return handleError({
+      return handleError(attachSourceErrorMetadata({
         code: 'F5210',
         resourceType,
         resourceId,
-        stack: err.stack || (new Error()).stack,
-        sourceError: err
-      }, environment);
+        stack: err.stack || (new Error()).stack
+      }, err), environment);
     }
 
     // Check for "No resources found" errors
-    if (err.message && err.message.includes('No resources found')) {
+    if (err.message && (err.message.includes('No resources found') || err.message.includes('Search returned no match'))) {
       const resourceType = typeof params === 'object' ? resourceTypeOrRef : resourceTypeOrRef.split('/')[0];
       const searchParams = typeof params === 'object' ? params : {};
-      return handleError({
+      return handleError(attachSourceErrorMetadata({
         code: 'F5211',
         resourceType,
         searchParams: JSON.stringify(searchParams),
-        stack: err.stack || (new Error()).stack,
-        sourceError: err
-      }, environment);
+        stack: err.stack || (new Error()).stack
+      }, err), environment);
     }
 
     // Check for "Multiple resources found" errors
-    if (err.message && err.message.includes('Multiple resources found')) {
+    if (err.message && (err.message.includes('Multiple resources found') || err.message.includes('Search returned multiple matches'))) {
       const resourceType = typeof params === 'object' ? resourceTypeOrRef : resourceTypeOrRef.split('/')[0];
       const searchParams = typeof params === 'object' ? params : {};
-      const match = err.message.match(/\((\d+) found\)/);
+      const match = err.message.match(/\((\d+)(?: found)?\)/);
       const resultCount = match ? match[1] : 'multiple';
-      return handleError({
+      return handleError(attachSourceErrorMetadata({
         code: 'F5212',
         resourceType,
         searchParams: JSON.stringify(searchParams),
         resultCount,
-        stack: err.stack || (new Error()).stack,
-        sourceError: err
-      }, environment);
+        stack: err.stack || (new Error()).stack
+      }, err), environment);
     }
 
     // Generic FHIR client error
-    return handleError({
+    return handleError(attachSourceErrorMetadata({
       code: 'F5203',
       operation: operationName,
       errorMessage: err.message || String(err),
-      stack: err.stack || (new Error()).stack,
-      sourceError: err
-    }, environment);
+      stack: err.stack || (new Error()).stack
+    }, err), environment);
   }
 
   /**
@@ -131,39 +137,36 @@ function createFhirClientWrappers(getFhirClient) {
       } catch (err) {
         // Check if it's a timeout error
         if (err.name === 'AbortError' || (err.message && err.message.includes('timeout'))) {
-          return handleError({
+          return handleError(attachSourceErrorMetadata({
             code: 'F5202',
             operation: operationName,
             timeout: client.config?.timeout || 30000,
-            stack: err.stack || (new Error()).stack,
-            sourceError: err
-          }, this.environment);
+            stack: err.stack || (new Error()).stack
+          }, err), this.environment);
         }
 
         // Check for resource not found (404)
-        if (err.response && err.response.status === 404) {
+        if (getErrorStatus(err) === 404) {
           // Try to extract resource type and ID from error or args
           const resourceType = args[0];
           const resourceId = args[1];
           if (resourceType && resourceId) {
-            return handleError({
+            return handleError(attachSourceErrorMetadata({
               code: 'F5210',
               resourceType,
               resourceId,
-              stack: err.stack || (new Error()).stack,
-              sourceError: err
-            }, this.environment);
+              stack: err.stack || (new Error()).stack
+            }, err), this.environment);
           }
         }
 
         // Generic FHIR client error
-        return handleError({
+        return handleError(attachSourceErrorMetadata({
           code: 'F5203',
           operation: operationName,
           errorMessage: err.message || String(err),
-          stack: err.stack || (new Error()).stack,
-          sourceError: err
-        }, this.environment);
+          stack: err.stack || (new Error()).stack
+        }, err), this.environment);
       }
     };
   }

--- a/test/http-error-redaction.test.js
+++ b/test/http-error-redaction.test.js
@@ -1,0 +1,125 @@
+import fumifier from '../dist/index.mjs';
+import * as chai from 'chai';
+
+const { expect } = chai;
+
+function createTransportLikeError({
+  message,
+  status,
+  request,
+  operationOutcome,
+  extra = {}
+}) {
+  const err = new Error(message);
+  err.name = 'FhirClientError';
+  err.code = 'FhirClientError';
+  if (typeof status === 'number') err.status = status;
+  if (request) err.request = request;
+  if (operationOutcome) err.operationOutcome = operationOutcome;
+  Object.assign(err, extra);
+  return err;
+}
+
+describe('HTTP error redaction', function() {
+  it('does not emit raw nested FHIR client errors in verbose diagnostics', async function() {
+    const expr = await fumifier("$literal('Patient', {'identifier':'http://test|123'})", {
+      fhirClient: {
+        async toLiteral() {
+          throw createTransportLikeError({
+            message: 'upstream unauthorized',
+            status: 401,
+            request: {
+              method: 'GET',
+              url: 'Patient?identifier=http%3A%2F%2Ftest%7C123'
+            },
+            operationOutcome: {
+              resourceType: 'OperationOutcome',
+              issue: [{ severity: 'error' }]
+            },
+            extra: {
+              config: {
+                auth: { username: 'secret-user', password: 'secret-pass' },
+                headers: { authorization: 'Basic c2VjcmV0LXVzZXI6c2VjcmV0LXBhc3M=' }
+              }
+            }
+          });
+        }
+      }
+    });
+
+    const report = await expr.evaluateVerbose({});
+    const diagnostic = report.diagnostics.error[0];
+
+    expect(report.ok).to.equal(false);
+    expect(report.status).to.equal(206);
+    expect(diagnostic).to.include({
+      code: 'F5203',
+      operation: 'literal',
+      errorMessage: 'upstream unauthorized',
+      sourceMessage: 'upstream unauthorized',
+      sourceErrorCode: 'FhirClientError',
+      status: 401
+    });
+    expect(diagnostic.request).to.deep.equal({
+      method: 'GET',
+      url: 'Patient?identifier=http%3A%2F%2Ftest%7C123'
+    });
+    expect(diagnostic.operationOutcome).to.deep.equal({
+      resourceType: 'OperationOutcome',
+      issue: [{ severity: 'error' }]
+    });
+
+    const serialized = JSON.stringify(diagnostic);
+    expect(serialized).not.to.contain('secret-user');
+    expect(serialized).not.to.contain('secret-pass');
+    expect(serialized).not.to.contain('Basic c2VjcmV0LXVzZXI6c2VjcmV0LXBhc3M=');
+    expect(serialized).not.to.contain('"sourceError"');
+    expect(serialized).not.to.contain('"config"');
+    expect(serialized).not.to.contain('"auth"');
+  });
+
+  it('maps top-level FhirClientError 404s to F5210 without exposing raw nested cause', async function() {
+    const expr = await fumifier("$resolve('Patient/123')", {
+      fhirClient: {
+        async resolve() {
+          throw createTransportLikeError({
+            message: 'FHIR request failed with status 404',
+            status: 404,
+            request: {
+              method: 'GET',
+              url: 'Patient/123',
+              resourceType: 'Patient',
+              id: '123'
+            },
+            extra: {
+              response: {
+                status: 404,
+                data: {
+                  resourceType: 'OperationOutcome',
+                  issue: [{ severity: 'error' }]
+                },
+                headers: { authorization: 'Basic should-not-leak' }
+              }
+            }
+          });
+        }
+      }
+    });
+
+    const report = await expr.evaluateVerbose({});
+    const diagnostic = report.diagnostics.error[0];
+
+    expect(report.ok).to.equal(false);
+    expect(report.status).to.equal(206);
+    expect(diagnostic).to.include({
+      code: 'F5210',
+      resourceType: 'Patient',
+      resourceId: '123',
+      status: 404
+    });
+
+    const serialized = JSON.stringify(diagnostic);
+    expect(serialized).not.to.contain('"sourceError"');
+    expect(serialized).not.to.contain('Basic should-not-leak');
+  });
+});

--- a/test/http-error-redaction.test.js
+++ b/test/http-error-redaction.test.js
@@ -122,4 +122,79 @@ describe('HTTP error redaction', function() {
     expect(serialized).not.to.contain('"sourceError"');
     expect(serialized).not.to.contain('Basic should-not-leak');
   });
+
+  it('keeps search-style 404s as generic F5203 errors when no concrete resource id is available', async function() {
+    const expr = await fumifier("$literal('Patient', {'identifier':'http://test|123'})", {
+      fhirClient: {
+        async toLiteral() {
+          throw createTransportLikeError({
+            message: 'FHIR request failed with status 404',
+            status: 404,
+            request: {
+              method: 'GET',
+              url: 'Patient?identifier=http%3A%2F%2Ftest%7C123',
+              resourceType: 'Patient'
+            },
+            extra: {
+              response: {
+                status: 404,
+                headers: { authorization: 'Basic should-not-leak' }
+              }
+            }
+          });
+        }
+      }
+    });
+
+    const report = await expr.evaluateVerbose({});
+    const diagnostic = report.diagnostics.error[0];
+
+    expect(report.ok).to.equal(false);
+    expect(report.status).to.equal(206);
+    expect(diagnostic).to.include({
+      code: 'F5203',
+      operation: 'literal',
+      status: 404
+    });
+    expect(diagnostic).not.to.have.property('resourceId');
+
+    const serialized = JSON.stringify(diagnostic);
+    expect(serialized).not.to.contain('undefined');
+    expect(serialized).not.to.contain('Basic should-not-leak');
+  });
+
+  it('does not emit raw nested eval wrapper errors in verbose diagnostics', async function() {
+    const expr = await fumifier('$eval("$boom()")');
+    expr.registerFunction('boom', function() {
+      const err = new Error('inner unauthorized');
+      err.config = {
+        auth: { username: 'secret-user', password: 'secret-pass' },
+        headers: { authorization: 'Basic c2VjcmV0' }
+      };
+      err.cause = {
+        auth: { username: 'secret-user', password: 'secret-pass' },
+        headers: { authorization: 'Basic c2VjcmV0' }
+      };
+      throw err;
+    });
+
+    const report = await expr.evaluateVerbose({});
+    const diagnostic = report.diagnostics.error[0];
+
+    expect(report.ok).to.equal(false);
+    expect(report.status).to.equal(422);
+    expect(diagnostic).to.include({
+      code: 'D3121',
+      sourceMessage: 'inner unauthorized'
+    });
+
+    const serialized = JSON.stringify(diagnostic);
+    expect(serialized).not.to.contain('secret-user');
+    expect(serialized).not.to.contain('secret-pass');
+    expect(serialized).not.to.contain('Basic c2VjcmV0');
+    expect(serialized).not.to.contain('"error"');
+    expect(serialized).not.to.contain('"cause"');
+    expect(serialized).not.to.contain('"config"');
+    expect(serialized).not.to.contain('"auth"');
+  });
 });

--- a/test/use-fhir-server.test.js
+++ b/test/use-fhir-server.test.js
@@ -229,6 +229,37 @@ describe('$useFhirServer', function() {
     });
   });
 
+  it('does not expose inline auth config in verbose diagnostics for resolver failures', async function() {
+    const expr = await fumifier("($useFhirServer('http://public.fhir.org/r4', {'authType':'BASIC','username':'u','password':'p'}); $search('Patient', {}).total)", {
+      connectionResolver: () => {
+        const err = new Error('resolver boom');
+        err.config = {
+          auth: { username: 'u', password: 'p' },
+          headers: { authorization: 'Basic dTpw' }
+        };
+        throw err;
+      }
+    });
+
+    const report = await expr.evaluateVerbose({});
+
+    expect(report.ok).to.equal(false);
+    expect(report.status).to.equal(422);
+    expect(report.diagnostics.error).to.have.lengthOf(1);
+    expect(report.diagnostics.error[0]).to.include({
+      code: 'D3201',
+      token: 'useFhirServer',
+      sourceMessage: 'resolver boom'
+    });
+
+    const serialized = JSON.stringify(report.diagnostics.error[0]);
+    expect(serialized).not.to.contain('"sourceError"');
+    expect(serialized).not.to.contain('"config"');
+    expect(serialized).not.to.contain('"auth"');
+    expect(serialized).not.to.contain('"password"');
+    expect(serialized).not.to.contain('Basic dTpw');
+  });
+
   it('keeps $translateCode on terminology runtime after switching FHIR servers', async function() {
     const defaultClient = createClient(1);
     const resolverCalls = [];


### PR DESCRIPTION
## Problem statement

`fumifier` could retain raw nested HTTP/client errors on enumerable wrapper fields and other nested error slots that survived into verbose diagnostics. In verbose mode, diagnostics collection could spread those nested objects into the public report shape, which allowed auth-related config and other transport details to leak.

## Root cause in this module

- FHIR wrapper errors in `src/utils/fhirClientWrappers.js` attached the original error object directly on enumerable `sourceError` fields.
- The `$useFhirServer` resolver failure path (`D3201`) did the same for connection-switch errors.
- Other wrapped/runtime paths such as `$eval` (`D3121`) and mapping wrapper failures could also retain nested raw errors under fields like `error` or `sourceError`.
- `src/utils/diagnostics.js` removed `stack` from collected diagnostics but otherwise spread enumerable properties unchanged, so nested raw error-like objects could still serialize sensitive auth/config/header data.

## Summary of code and test changes

- Added shared helper logic in `src/utils/diagnostics.js` to attach raw causes non-enumerably while copying only safe metadata (`sourceMessage`, `sourceErrorCode`, `status`, `request`, `operationOutcome`).
- Tightened diagnostic sanitization so nested `sourceError`, `error`, and `cause` objects are reduced to safe top-level metadata before the raw nested objects are removed from verbose diagnostics.
- Updated FHIR wrapper errors, `$eval`/mapping wrapper errors, and `D3201` to stop exposing raw nested errors on enumerable fields while preserving actionable safe metadata.
- Corrected normalized 404 handling in `src/utils/fhirClientWrappers.js` so `F5210` is only emitted when a real resource identity is available; search-style 404s now remain generic `F5203` errors instead of producing malformed `resourceId: undefined` diagnostics.
- Added focused regressions for FHIR wrapper failures, search-style 404s, nested `$eval` wrapper failures, and `$useFhirServer` resolver failures to assert that verbose diagnostics do not expose auth/config details.

## Validation run for this module

- Focused build for `fumifier`.
- Focused Mocha run for `test/http-error-redaction.test.js`, `test/use-fhir-server.test.js`, and `test/mapping-repository.test.js`.

## Known risks, follow-ups, or rollout notes

- Consumers that were enumerating raw nested error objects from wrapped runtime errors will no longer see those raw objects in JSON/verbose outputs.
- Safe top-level fields such as `status`, `request`, `operationOutcome`, `sourceMessage`, and `sourceErrorCode` are preserved when available to keep diagnostics actionable.

## Issue Resolution
- Resolves #89 