### PR TITLE
Feat/HOF Issues 86, 87, 88, 96, 97

### DIFF
--- a/draft-release-notes-hof-issues-86-87-88-96-97.md
+++ b/draft-release-notes-hof-issues-86-87-88-96-97.md
@@ -1,0 +1,20 @@
+# Draft Release Notes: HOF Issues 86, 87, 88, 96, 97
+
+`fumifier` now adds four public higher-order functions: `$safe`, `$all`, `$any`, and `$memoize`.
+
+These additions let expressions wrap failure-prone helpers without throwing, evaluate collection predicates with sequential sync/async short-circuiting, and reuse repeated results within a single evaluation.
+
+`$search(..., { fetchAll: true, transform })` now also works from the public expression surface when `transform` is defined as an inline `fumifier` function, not just as a native JavaScript callback.
+
+Highlights:
+
+- `$safe()` returns structured success/error result objects with sanitized public error fields.
+- `$all()` and `$any()` support sync and async predicates and preserve deterministic short-circuit order.
+- `$memoize()` caches fulfilled results for one evaluation, shares in-flight async work for duplicate calls, and drops failed entries so later retries can re-run.
+- Wrapped mapping parse failures now preserve informative parser messages instead of degrading to `[object Object]`.
+
+Compatibility notes:
+
+- `$memoize()` rejects function-valued and symbol-valued argument trees.
+- `$search` transform follows the `@outburn/fhir-client` contract and is only valid with `fetchAll: true`.
+- `maxResults` still applies to raw fetched resources before transform filtering.

--- a/src/fumifier.js
+++ b/src/fumifier.js
@@ -2372,10 +2372,17 @@ var fumifier = (function() {
         // error parsing the mapping expression - customize error format for mapping context
         const nestedParseError = parseError.error || parseError;
         populateMessage(nestedParseError, this.environment);
+        const sourceMessage = typeof nestedParseError.message === 'string'
+          ? nestedParseError.message
+          : typeof parseError.message === 'string'
+            ? parseError.message
+            : typeof parseError.value === 'string'
+              ? parseError.value
+              : String(nestedParseError);
         throw attachSourceErrorMetadata({
           code: "F3002",
           value: mappingKey,
-          sourceMessage: parseError.message || parseError.value || nestedParseError.message || String(nestedParseError),
+          sourceMessage,
           stack: (new Error()).stack
         }, nestedParseError);
       }

--- a/src/utils/errorCodes.js
+++ b/src/utils/errorCodes.js
@@ -178,6 +178,7 @@ const errorCodes = {
   "D3139": "The $single() function expected exactly 1 matching result.  Instead it matched 0.",
   "D3140": "Malformed URL passed to ${{{functionName}}}(): {{value}}",
   "D3141": "{{{message}}}",
+  "D3142": "$memoize() arguments cannot contain functions or symbols. Received: {{value}}",
   "D3200": "Cannot switch FHIR server to {{target}}: connection resolver is not configured.",
   "D3201": "Failed to switch FHIR server to {{target}}: {{{sourceMessage}}}",
   "F0001": "Failed to extract root FHIR package context. This may hinder AST mobility. FHIR Package Explorer < v1.5.0 doesn't support this operation.",

--- a/src/utils/fhirClientWrappers.js
+++ b/src/utils/fhirClientWrappers.js
@@ -10,6 +10,16 @@ import { populateMessage } from './errorCodes.js';
 import { attachSourceErrorMetadata } from './diagnostics.js';
 
 /**
+ * Determine whether a value can be used as a search transform callback.
+ * Accepts native JavaScript functions and fumifier callables that expose apply().
+ * @param {*} value - Candidate transform value.
+ * @returns {boolean} True when the value is callable by the wrapper bridge.
+ */
+function isCallableTransform(value) {
+  return typeof value === 'function' || Boolean(value && (value._fumifier_function === true || value._fumifier_lambda === true) && typeof value.apply === 'function');
+}
+
+/**
  * Creates user-facing wrapper functions for FHIR client operations.
  * These functions are bound to the environment and provide controlled access to the FHIR client.
  * @param {Function} getFhirClient - Function that retrieves the current FHIR client from environment
@@ -196,6 +206,38 @@ function createFhirClientWrappers(getFhirClient) {
     };
   }
 
+  /**
+   * Adapt nested search transform options so expression-defined fumifier callables
+   * cross the wrapper boundary as JavaScript callbacks for fhir-client.
+   * @param {*} options - Raw search options from the expression surface.
+   * @param {Object} environment - Current execution environment.
+   * @returns {*} Original options or a shallow-cloned options object with an adapted transform.
+   */
+  function normalizeSearchOptions(options, environment) {
+    if (!options || typeof options !== 'object') {
+      return options;
+    }
+
+    if (!Object.prototype.hasOwnProperty.call(options, 'transform') || typeof options.transform === 'undefined') {
+      return options;
+    }
+
+    if (typeof options.transform === 'function') {
+      return options;
+    }
+
+    if (!isCallableTransform(options.transform)) {
+      return options;
+    }
+
+    return {
+      ...options,
+      transform: async function(resource, mode, index, entry) {
+        return await options.transform.apply({ environment, input: resource }, [resource, mode, index, entry]);
+      }
+    };
+  }
+
   return {
     /**
      * $search(resourceType, params?, options?) - Search for FHIR resources
@@ -205,7 +247,7 @@ function createFhirClientWrappers(getFhirClient) {
      * @returns {Promise<Object>} Search results
      */
     search: wrapOperation(async function(resourceType, params, options) {
-      return await this.search(resourceType, params, options);
+      return await this.search(resourceType, params, normalizeSearchOptions(options, this.environment));
     }, 'search'),
 
     /**

--- a/src/utils/functions.js
+++ b/src/utils/functions.js
@@ -181,7 +181,12 @@ const functions = (() => {
     var result;
 
     if (func && func._fumifier_function === true && typeof func.implementation === 'function') {
-      result = func.implementation.apply(self, args);
+      var validatedArgs = args;
+      if (func.signature && typeof func.signature.validate === 'function') {
+        var validationContext = self && typeof self === 'object' && Object.prototype.hasOwnProperty.call(self, 'input') ? self.input : self;
+        validatedArgs = func.signature.validate(args, validationContext);
+      }
+      result = func.implementation.apply(self, validatedArgs);
     } else {
       result = func.apply(self, args);
     }

--- a/src/utils/functions.js
+++ b/src/utils/functions.js
@@ -12,6 +12,7 @@ License: See the LICENSE file included with this package for the terms that appl
 import utils from './utils.js';
 import defineFunction from './defineFunction.js';
 import { attachSourceErrorMetadata } from './diagnostics.js';
+import { populateMessage } from './errorCodes.js';
 
 const functions = (() => {
 
@@ -128,9 +129,22 @@ const functions = (() => {
   function sanitizeSafeError(error) {
     var result = {};
     if (error && typeof error === 'object') {
+      var explicitSourceMessage = typeof error.sourceMessage === 'string' ? error.sourceMessage : undefined;
+      var explicitSourceErrorCode = typeof error.sourceErrorCode === 'string' ? error.sourceErrorCode : undefined;
+
+      if (typeof error.code === 'string' && (typeof error.message !== 'string' || error.message.length === 0)) {
+        try {
+          populateMessage(error);
+        } catch (_) {
+          // Ignore message population failures and fall back to raw fields below.
+        }
+      }
+
       if (typeof error.code === 'string') result.code = error.code;
       if (typeof error.message === 'string') result.message = error.message;
-      attachSourceErrorMetadata(result, error);
+      attachSourceErrorMetadata(result, error.sourceError || error);
+      if (typeof explicitSourceMessage === 'string') result.sourceMessage = explicitSourceMessage;
+      if (typeof explicitSourceErrorCode === 'string') result.sourceErrorCode = explicitSourceErrorCode;
     } else {
       result.message = String(error);
     }

--- a/src/utils/functions.js
+++ b/src/utils/functions.js
@@ -10,6 +10,8 @@ License: See the LICENSE file included with this package for the terms that appl
 */
 
 import utils from './utils.js';
+import defineFunction from './defineFunction.js';
+import { attachSourceErrorMetadata } from './diagnostics.js';
 
 const functions = (() => {
 
@@ -72,6 +74,109 @@ const functions = (() => {
       return '{' + pairs.join(',') + '}';
     }
     return JSON.stringify(String(value));
+  }
+
+  /**
+   * Build a deterministic, type-tagged cache key for memoized arguments.
+   * Rejects functions and symbols anywhere in the value tree.
+   * @param {*} value - Value to serialize for memoization.
+   * @returns {string} Stable memoization key.
+   */
+  function _stableMemoizeKey(value) {
+    if (typeof value === 'undefined') return 'u';
+    if (value === null) return 'l:null';
+
+    var type = typeof value;
+    if (type === 'string') return 's:' + JSON.stringify(value);
+    if (type === 'number') return 'n:' + JSON.stringify(value);
+    if (type === 'boolean') return 'b:' + JSON.stringify(value);
+    if (type === 'bigint') return 'g:' + String(value);
+    if (type === 'symbol' || isFunction(value)) {
+      throw {
+        code: 'D3142',
+        stack: (new Error()).stack,
+        value: type === 'symbol' ? String(value) : '$function'
+      };
+    }
+
+    if (Array.isArray(value)) {
+      var arrayParts = new Array(value.length);
+      for (var i = 0; i < value.length; i++) {
+        arrayParts[i] = _stableMemoizeKey(value[i]);
+      }
+      return 'a:[' + arrayParts.join(',') + ']';
+    }
+
+    if (type === 'object') {
+      var keys = Object.keys(value).sort();
+      var objectParts = new Array(keys.length);
+      for (var k = 0; k < keys.length; k++) {
+        var key = keys[k];
+        objectParts[k] = JSON.stringify(key) + ':' + _stableMemoizeKey(value[key]);
+      }
+      return 'o:{' + objectParts.join(',') + '}';
+    }
+
+    return type + ':' + JSON.stringify(String(value));
+  }
+
+  /**
+   * Reduce an error to the safe public fields exposed by $safe().
+   * @param {*} error - Original thrown or rejected value.
+   * @returns {Object} Sanitized error summary.
+   */
+  function sanitizeSafeError(error) {
+    var result = {};
+    if (error && typeof error === 'object') {
+      if (typeof error.code === 'string') result.code = error.code;
+      if (typeof error.message === 'string') result.message = error.message;
+      attachSourceErrorMetadata(result, error);
+    } else {
+      result.message = String(error);
+    }
+
+    return result;
+  }
+
+  /**
+   * Normalize HOF collection input so undefined becomes an empty sequence and
+   * singleton values become a one-item sequence.
+   * @param {*} arr - Raw collection input.
+   * @returns {Array} Normalized collection value.
+   */
+  function normalizeCollectionInput(arr) {
+    if (typeof arr === 'undefined') {
+      return createSequence();
+    }
+
+    if (!Array.isArray(arr)) {
+      return createSequence(arr);
+    }
+
+    return arr;
+  }
+
+  /**
+   * Invoke either a native JavaScript function or a fumifier function wrapper.
+   * @param {*} func - Callable value to invoke.
+   * @param {Object} self - Invocation context.
+   * @param {Array} args - Positional arguments.
+   * @returns {Promise<*>} Callable result.
+   */
+  async function invokeCallable(func, self, args) {
+    var result;
+
+    if (func && func._fumifier_function === true && typeof func.implementation === 'function') {
+      result = func.implementation.apply(self, args);
+    } else {
+      result = func.apply(self, args);
+    }
+
+    if (isPromise(result)) {
+      result = await result;
+    }
+
+    return result;
   }
 
   /**
@@ -1962,6 +2067,125 @@ const functions = (() => {
   }
 
   /**
+     * Determine whether every item in a collection matches a predicate.
+     * Undefined input is treated as an empty collection.
+     * @param {Array|*} [arr] - array (or single value) to test
+     * @param {Function} func - predicate function
+     * @returns {boolean} True when all predicate evaluations are truthy
+     */
+  async function all(arr, func) {
+    arr = normalizeCollectionInput(arr);
+
+    for (var i = 0; i < arr.length; i++) {
+      var entry = arr[i];
+      var func_args = hofFuncArgs(func, entry, i, arr);
+      var res = await func.apply(this, func_args);
+      if (!boolean(res)) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  /**
+     * Determine whether any item in a collection matches a predicate.
+     * Undefined input is treated as an empty collection.
+     * @param {Array|*} [arr] - array (or single value) to test
+     * @param {Function} func - predicate function
+     * @returns {boolean} True when any predicate evaluation is truthy
+     */
+  async function any(arr, func) {
+    arr = normalizeCollectionInput(arr);
+
+    for (var i = 0; i < arr.length; i++) {
+      var entry = arr[i];
+      var func_args = hofFuncArgs(func, entry, i, arr);
+      var res = await func.apply(this, func_args);
+      if (boolean(res)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  /**
+     * Wrap a callable so it returns a result object instead of throwing.
+     * @param {Function} func - function to wrap
+     * @returns {Object} Wrapped fumifier function
+     */
+  function safe(func) {
+    if (!isFunction(func)) {
+      throw {
+        code: 'T0410',
+        stack: (new Error()).stack,
+        token: 'safe',
+        index: 1
+      };
+    }
+
+    return defineFunction(async function() {
+      try {
+        var result = await invokeCallable(func, this, Array.prototype.slice.call(arguments));
+        return {
+          ok: true,
+          result,
+          error: undefined
+        };
+      } catch (error) {
+        return {
+          ok: false,
+          result: undefined,
+          error: sanitizeSafeError(error)
+        };
+      }
+    });
+  }
+
+  /**
+     * Memoize a callable for the lifetime of the returned wrapper.
+     * @param {Function} func - function to memoize
+     * @returns {Object} Wrapped fumifier function
+     */
+  function memoize(func) {
+    if (!isFunction(func)) {
+      throw {
+        code: 'T0410',
+        stack: (new Error()).stack,
+        token: 'memoize',
+        index: 1
+      };
+    }
+
+    var cache = new Map();
+
+    return defineFunction(async function() {
+      var args = Array.prototype.slice.call(arguments);
+      var key = _stableMemoizeKey(args);
+
+      if (cache.has(key)) {
+        return await cache.get(key);
+      }
+
+      var self = this;
+      var pending = Promise.resolve().then(async function() {
+        return await invokeCallable(func, self, args);
+      });
+      cache.set(key, pending);
+
+      try {
+        var resolved = await pending;
+        cache.set(key, Promise.resolve(resolved));
+        return resolved;
+      } catch (error) {
+        cache.delete(key);
+        throw error;
+      }
+    });
+  }
+
+  /**
      * Given an array, find the single element matching a specified condition
      * Throws an exception if the number of matching elements is not exactly one
      * @param {Array} [arr] - array to filter
@@ -2732,7 +2956,7 @@ const functions = (() => {
     match, contains, replace, split, join, startsWith, endsWith, matches, isEmpty, isNumeric: _isNumeric,
     formatNumber, formatBase, number, floor, ceil, round, abs, sqrt, power, random,
     boolean, boolize, not,
-    map, zip, filter, pMap, pLimit, first, single, foldLeft, sift, omitKeys, selectKeys,
+    map, zip, filter, pMap, pLimit, first, all, any, safe, memoize, single, foldLeft, sift, omitKeys, selectKeys,
     keys, lookup, append, exists, spread, merge, reverse, each, error, assert, type, sort, shuffle, distinct,
     base64encode, base64decode,  encodeUrlComponent, encodeUrl, decodeUrlComponent, decodeUrl,
     wait, rightNow, initCapOnce, initCap, uuid, reference, hash

--- a/src/utils/functions.js
+++ b/src/utils/functions.js
@@ -89,7 +89,13 @@ const functions = (() => {
 
     var type = typeof value;
     if (type === 'string') return 's:' + JSON.stringify(value);
-    if (type === 'number') return 'n:' + JSON.stringify(value);
+    if (type === 'number') {
+      if (Number.isNaN(value)) return 'n:NaN';
+      if (value === Infinity) return 'n:Infinity';
+      if (value === -Infinity) return 'n:-Infinity';
+      if (Object.is(value, -0)) return 'n:-0';
+      return 'n:' + JSON.stringify(value);
+    }
     if (type === 'boolean') return 'b:' + JSON.stringify(value);
     if (type === 'bigint') return 'g:' + String(value);
     if (type === 'symbol' || isFunction(value)) {

--- a/src/utils/registerNativeFn.js
+++ b/src/utils/registerNativeFn.js
@@ -75,6 +75,10 @@ function registerNativeFn(staticFrame, functionEval) {
   // signature: array, number, function (mapper), optional function (key)
   staticFrame.bind('pLimit', defineFunction(fn.pLimit, '<anff?>'));
   staticFrame.bind('first', defineFunction(fn.first, '<af>'));
+  staticFrame.bind('all', defineFunction(fn.all, '<af>'));
+  staticFrame.bind('any', defineFunction(fn.any, '<af>'));
+  staticFrame.bind('safe', defineFunction(fn.safe, '<f-:f>'));
+  staticFrame.bind('memoize', defineFunction(fn.memoize, '<f-:f>'));
   staticFrame.bind('single', defineFunction(fn.single, '<af?>'));
   staticFrame.bind('reduce', defineFunction(fn.foldLeft, '<afj?:j>')); // TODO <f<jj:j>a<j>j?:j>
   staticFrame.bind('sift', defineFunction(fn.sift, '<o-f?:o>'));

--- a/test/all-any-hof.test.js
+++ b/test/all-any-hof.test.js
@@ -1,0 +1,52 @@
+import fumifier from '../dist/index.mjs';
+import * as chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+
+const { expect, use } = chai;
+use(chaiAsPromised);
+
+describe('$all and $any HOFs', function() {
+  it('normalizes undefined input to deterministic empty-collection booleans', async function() {
+    const expr = await fumifier('[ $all(nothing, function($v){$v}), $any(nothing, function($v){$v}) ]');
+    const res = await expr.evaluate({});
+
+    expect(res).to.deep.equal([true, false]);
+  });
+
+  it('supports singleton input, chaining, and callback arguments', async function() {
+    const expr = await fumifier('[5 ~> $all(function($v,$i,$a){$v = 5 and $i = 0 and $a[0] = 5}), [1,2,3] ~> $any(function($v){$v = 2})]');
+    const res = await expr.evaluate({});
+
+    expect(res).to.deep.equal([true, true]);
+  });
+
+  it('$any short-circuits async predicates in collection order', async function() {
+    const calls = [];
+    const expr = await fumifier('$any([1,2,3,4], $predicate)');
+    expr.assign('predicate', async (value) => {
+      calls.push(value);
+      await new Promise(resolve => setTimeout(resolve, 5));
+      return value === 2;
+    });
+
+    const res = await expr.evaluate({});
+
+    expect(res).to.equal(true);
+    expect(calls).to.deep.equal([1, 2]);
+  });
+
+  it('$all short-circuits async predicates on the first falsy result', async function() {
+    const calls = [];
+    const expr = await fumifier('$all([2,4,5,8], $predicate)');
+    expr.assign('predicate', async (value) => {
+      calls.push(value);
+      await new Promise(resolve => setTimeout(resolve, 5));
+      return value % 2 === 0;
+    });
+
+    const res = await expr.evaluate({});
+
+    expect(res).to.equal(false);
+    expect(calls).to.deep.equal([2, 4, 5]);
+  });
+});

--- a/test/first-hof.test.js
+++ b/test/first-hof.test.js
@@ -48,6 +48,21 @@ describe('$first HOF', function() {
     expect(res).to.deep.equal({ x: 2 });
   });
 
+  it('short-circuits async predicates after the first match', async function() {
+    const calls = [];
+    const expr = await fumifier('$first([1,2,3,4], $nativeAsync)');
+    expr.assign('nativeAsync', async function (value) {
+      calls.push(value);
+      await new Promise(resolve => setTimeout(resolve, 5));
+      return value >= 2;
+    });
+
+    const res = await expr.evaluate({});
+
+    expect(res).to.equal(2);
+    expect(calls).to.deep.equal([1, 2]);
+  });
+
   it('returns undefined when no item matches', async function() {
     const expr = await fumifier('[1,2] ~> $first(function($v){$v > 10})');
     const res = await expr.evaluate({});

--- a/test/memoize-hof.test.js
+++ b/test/memoize-hof.test.js
@@ -1,0 +1,99 @@
+import fumifier from '../dist/index.mjs';
+import * as chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+
+const { expect, use } = chai;
+use(chaiAsPromised);
+
+describe('$memoize HOF', function() {
+  it('accepts the wrapped function from context via the signature - flag', async function() {
+    let callCount = 0;
+    const expr = await fumifier('($memoUpper := $uppercase.$memoize(); [$memoUpper("hello"), $memoUpper("hello")])');
+    expr.assign('uppercase', (value) => {
+      callCount += 1;
+      return String(value).toUpperCase();
+    });
+
+    const res = await expr.evaluate({});
+
+    expect(res).to.deep.equal(['HELLO', 'HELLO']);
+    expect(callCount).to.equal(1);
+  });
+
+  it('reuses cached results within one evaluation and resets across evaluations', async function() {
+    let callCount = 0;
+    const expr = await fumifier('($memo := $memoize($counted); [$memo(1), $memo(1), $memo(2)])');
+    expr.assign('counted', (value) => {
+      callCount += 1;
+      return value * 10;
+    });
+
+    const first = await expr.evaluate({});
+    const second = await expr.evaluate({});
+
+    expect(first).to.deep.equal([10, 10, 20]);
+    expect(second).to.deep.equal([10, 10, 20]);
+    expect(callCount).to.equal(4);
+  });
+
+  it('shares the same in-flight promise for duplicate async arguments', async function() {
+    let callCount = 0;
+    const expr = await fumifier('($memo := $memoize($countedAsync); $pMap([1,1,2,2], $memo))');
+    expr.assign('countedAsync', async (value) => {
+      callCount += 1;
+      await new Promise(resolve => setTimeout(resolve, 5));
+      return value * 10;
+    });
+
+    const res = await expr.evaluate({});
+
+    expect(res).to.deep.equal([10, 10, 20, 20]);
+    expect(callCount).to.equal(2);
+  });
+
+  it('does not cache rejected results and retries after failure', async function() {
+    let callCount = 0;
+    const expr = await fumifier('($memo := $memoize($flaky); $first := $safe($memo)(1); $second := $safe($memo)(1); $third := $safe($memo)(1); [$first, $second, $third])');
+    expr.assign('flaky', async (value) => {
+      callCount += 1;
+      if (callCount === 1) {
+        throw new Error('boom');
+      }
+      return value * 2;
+    });
+
+    const res = await expr.evaluate({});
+
+    expect(res[0]).to.deep.equal({
+      ok: false,
+      result: undefined,
+      error: {
+        message: 'boom',
+        sourceMessage: 'boom'
+      }
+    });
+    expect(res[1]).to.deep.equal({
+      ok: true,
+      result: 2,
+      error: undefined
+    });
+    expect(res[2]).to.deep.equal({
+      ok: true,
+      result: 2,
+      error: undefined
+    });
+    expect(callCount).to.equal(2);
+  });
+
+  it('rejects unstable function-valued cache keys with a clear runtime error', async function() {
+    const expr = await fumifier('($memo := $memoize(function($value){$value}); $memo(function($v){$v}))');
+
+    try {
+      await expr.evaluate({});
+      expect.fail('Expected evaluation to reject');
+    } catch (err) {
+      expect(err.code).to.equal('D3142');
+      expect(err.message).to.equal('$memoize() arguments cannot contain functions or symbols. Received: "$function"');
+    }
+  });
+});

--- a/test/memoize-hof.test.js
+++ b/test/memoize-hof.test.js
@@ -51,6 +51,30 @@ describe('$memoize HOF', function() {
     expect(callCount).to.equal(2);
   });
 
+  it('distinguishes non-finite numbers and negative zero in memoize cache keys', async function() {
+    let callCount = 0;
+    const expr = await fumifier('($memo := $memoize($describe); [$memo($nan), $memo($inf), $memo($negInf), $memo($negZero), $memo($zero)])');
+    expr.assign('nan', NaN);
+    expr.assign('inf', Infinity);
+    expr.assign('negInf', -Infinity);
+    expr.assign('negZero', -0);
+    expr.assign('zero', 0);
+    expr.assign('describe', (value) => {
+      callCount += 1;
+      if (Number.isNaN(value)) return 'nan';
+      if (value === Infinity) return 'inf';
+      if (value === -Infinity) return '-inf';
+      if (Object.is(value, -0)) return '-0';
+      if (value === 0) return '0';
+      return String(value);
+    });
+
+    const res = await expr.evaluate({});
+
+    expect(res).to.deep.equal(['nan', 'inf', '-inf', '-0', '0']);
+    expect(callCount).to.equal(5);
+  });
+
   it('does not cache rejected results and retries after failure', async function() {
     let callCount = 0;
     const expr = await fumifier('($memo := $memoize($flaky); $first := $safe($memo)(1); $second := $safe($memo)(1); $third := $safe($memo)(1); [$first, $second, $third])');

--- a/test/safe-hof.test.js
+++ b/test/safe-hof.test.js
@@ -51,6 +51,34 @@ describe('$safe HOF', function() {
     });
   });
 
+  it('preserves wrapped source details when a saved mapping fails to parse', async function() {
+    const mappingCache = {
+      async getKeys() {
+        return ['syntaxError'];
+      },
+      async get(key) {
+        if (key !== 'syntaxError') {
+          throw new Error(`Unknown mapping: ${key}`);
+        }
+        return '$ + + $';
+      }
+    };
+
+    const expr = await fumifier('$safe($syntaxError)("hello")', { mappingCache });
+    const res = await expr.evaluate({});
+
+    expect(res.ok).to.equal(false);
+    expect(res.result).to.equal(undefined);
+    expect(res.error.code).to.equal('F3002');
+    expect(res.error.message).to.equal('Failed to parse mapping "syntaxError": Syntax error: symbol "+" used in a place where it is not allowed');
+    expect(res.error.message).to.not.contain('[object Object]');
+    expect(res.error.sourceMessage).to.be.a('string');
+    expect(res.error.sourceMessage).to.not.equal(res.error.message);
+    expect(res.error.sourceMessage).to.equal('Syntax error: symbol "+" used in a place where it is not allowed');
+    expect(res.error.sourceErrorCode).to.be.a('string');
+    expect(res.error.sourceErrorCode).to.not.equal('F3002');
+  });
+
   it('sanitizes thrown errors instead of exposing raw nested objects', async function() {
     const expr = await fumifier('$safe($explode)("Patient", "123")');
     expr.assign('explode', async (resourceType, id) => {

--- a/test/safe-hof.test.js
+++ b/test/safe-hof.test.js
@@ -1,0 +1,100 @@
+import fumifier from '../dist/index.mjs';
+import * as chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+
+const { expect, use } = chai;
+use(chaiAsPromised);
+
+describe('$safe HOF', function() {
+  it('accepts the wrapped function from context via the signature - flag', async function() {
+    const expr = await fumifier('($safeToMillis := $toMillis.$safe(); $safeToMillis("2025-01-02T03:04:05Z"))');
+    const res = await expr.evaluate({});
+
+    expect(res).to.deep.equal({
+      ok: true,
+      result: 1735787045000,
+      error: undefined
+    });
+  });
+
+  it('supports chaining and returns an ok result object on success', async function() {
+    const expr = await fumifier('"hello" ~> $safe($uppercase)()');
+    const res = await expr.evaluate({});
+
+    expect(res).to.deep.equal({
+      ok: true,
+      result: 'HELLO',
+      error: undefined
+    });
+  });
+
+  it('works with saved mappings exposed as callables', async function() {
+    const mappingCache = {
+      async getKeys() {
+        return ['shout'];
+      },
+      async get(key) {
+        if (key !== 'shout') {
+          throw new Error(`Unknown mapping: ${key}`);
+        }
+        return '$uppercase($)';
+      }
+    };
+
+    const expr = await fumifier('$safe($shout)("hello")', { mappingCache });
+    const res = await expr.evaluate({});
+
+    expect(res).to.deep.equal({
+      ok: true,
+      result: 'HELLO',
+      error: undefined
+    });
+  });
+
+  it('sanitizes thrown errors instead of exposing raw nested objects', async function() {
+    const expr = await fumifier('$safe($explode)("Patient", "123")');
+    expr.assign('explode', async (resourceType, id) => {
+      const err = new Error(`Lookup failed for ${resourceType}/${id}`);
+      err.code = 'HTTP_500';
+      err.status = 500;
+      err.request = {
+        method: 'GET',
+        url: `https://example.test/${resourceType}/${id}`,
+        headers: {
+          authorization: 'secret'
+        }
+      };
+      throw err;
+    });
+
+    const res = await expr.evaluate({});
+
+    expect(res.ok).to.equal(false);
+    expect(res.result).to.equal(undefined);
+    expect(res.error).to.deep.equal({
+      code: 'HTTP_500',
+      message: 'Lookup failed for Patient/123',
+      sourceMessage: 'Lookup failed for Patient/123',
+      sourceErrorCode: 'HTTP_500',
+      status: 500,
+      request: {
+        method: 'GET',
+        url: 'https://example.test/Patient/123'
+      }
+    });
+    expect(JSON.stringify(res.error)).not.to.contain('authorization');
+    expect(Object.keys(res.error)).not.to.include('sourceError');
+  });
+
+  it('fails fast when given a non-callable', async function() {
+    const expr = await fumifier('$safe(123)');
+
+    try {
+      await expr.evaluate({});
+      expect.fail('Expected evaluation to reject');
+    } catch (err) {
+      expect(err.code).to.equal('T0410');
+      expect(err.token).to.equal('safe');
+    }
+  });
+});

--- a/test/safe-hof.test.js
+++ b/test/safe-hof.test.js
@@ -17,6 +17,16 @@ describe('$safe HOF', function() {
     });
   });
 
+  it('preserves native signature validation for wrapped context-supplied functions', async function() {
+    const expr = await fumifier('($safeToMillis := $toMillis.$safe(); $safeToMillis(123))');
+    const res = await expr.evaluate({});
+
+    expect(res.ok).to.equal(false);
+    expect(res.result).to.equal(undefined);
+    expect(res.error.code).to.equal('T0410');
+    expect(res.error.code).to.not.equal('D3110');
+  });
+
   it('supports chaining and returns an ok result object on success', async function() {
     const expr = await fumifier('"hello" ~> $safe($uppercase)()');
     const res = await expr.evaluate({});

--- a/test/search-transform-hof.test.js
+++ b/test/search-transform-hof.test.js
@@ -1,0 +1,97 @@
+import fumifier from '../dist/index.mjs';
+import * as chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+
+const { expect, use } = chai;
+use(chaiAsPromised);
+
+function createClient(resources) {
+  return {
+    async search(resourceType, params, options = {}) {
+      const entries = resources.map((resource) => ({
+        fullUrl: `https://example.test/${resourceType}/${resource.id}`,
+        resource,
+        search: { mode: 'match' }
+      }));
+
+      if (options.fetchAll) {
+        if (typeof options.transform === 'function') {
+          const transformed = [];
+          for (let index = 0; index < entries.length; index++) {
+            const entry = entries[index];
+            const nextValue = await options.transform(entry.resource, entry.search.mode, index, entry);
+            if (typeof nextValue !== 'undefined') {
+              transformed.push(nextValue);
+            }
+          }
+          return transformed;
+        }
+
+        return entries.map((entry) => entry.resource);
+      }
+
+      return {
+        resourceType: 'Bundle',
+        type: 'searchset',
+        total: entries.length,
+        entry: entries
+      };
+    },
+    async getCapabilities() {
+      return { resourceType: 'CapabilityStatement' };
+    },
+    async resourceId() {
+      return resources[0]?.id;
+    },
+    async resolve() {
+      return resources[0];
+    },
+    async toLiteral() {
+      return `${resources[0]?.resourceType}/${resources[0]?.id}`;
+    }
+  };
+}
+
+describe('$search fetchAll transform bridge', function() {
+  it('adapts expression-defined transform lambdas inside the options object', async function() {
+    const client = createClient([
+      { resourceType: 'Patient', id: 'p1' },
+      { resourceType: 'Patient', id: 'p2' }
+    ]);
+
+    const expr = await fumifier("$search('Patient', {}, {'fetchAll': true, 'transform': function($resource, $mode, $index, $entry){$index = 0 ? {'id': $resource.id, 'mode': $mode, 'fullUrl': $entry.fullUrl} : undefined}})", {
+      fhirClient: client
+    });
+
+    const res = await expr.evaluate({});
+
+    expect(res).to.deep.equal([
+      {
+        id: 'p1',
+        mode: 'match',
+        fullUrl: 'https://example.test/Patient/p1'
+      }
+    ]);
+  });
+
+  it('leaves native JavaScript transform callbacks untouched', async function() {
+    const client = createClient([
+      { resourceType: 'Patient', id: 'p1' },
+      { resourceType: 'Patient', id: 'p2' }
+    ]);
+
+    const expr = await fumifier("$search('Patient', {}, $options)", {
+      fhirClient: client
+    });
+    expr.assign('options', {
+      fetchAll: true,
+      transform(resource, mode, index) {
+        return `${resource.id}:${mode}:${index}`;
+      }
+    });
+
+    const res = await expr.evaluate({});
+
+    expect(res).to.deep.equal(['p1:match:0', 'p2:match:1']);
+  });
+});


### PR DESCRIPTION
## Problem statement

`fumifier` was still missing the public higher-order functions `$safe`, `$all`, `$any`, and `$memoize`, even though the surrounding evaluator and HOF conventions were already in place.

At the same time, the public `$search(..., { fetchAll: true, transform })` surface could not be completed in `fumifier` until expression-defined lambdas inside the nested `options.transform` property could cross the `fumifier` to `@outburn/fhir-client` boundary as invokable JavaScript callbacks.

Issue `#96` also required a verification pass on `$first` so we could close any contract gaps without rewriting a feature that was already largely implemented.

Resolves #86, Resolves #87, Resolves #88, Resolves #96 and Resolves #97

## User-visible behavior changes

- Added `$safe(function?) -> function`.
- Added `$all(collection, predicate)` and `$any(collection, predicate)` with sequential sync/async short-circuit behavior.
- Added `$memoize(function?) -> function` with per-evaluation caching, stable argument keys, shared in-flight promise reuse, and failed-entry eviction.
- `$safe` and `$memoize` support the context-enabled first-argument form, so expressions such as `$toMillis.$safe()` and `$uppercase.$memoize()` work without explicitly passing `$`.
- `$search(..., { fetchAll: true, transform: function(...) { ... } })` now works from the public expression surface, including expression-defined lambdas nested inside the `options` object.
- `$safe()` now preserves sanitized public error fields while keeping informative wrapped source details, including wrapped mapping parse failures.
- `$first` keeps its existing public behavior, with the remaining async short-circuit gap closed by regression coverage rather than a feature rewrite.

## Implementation summary

- Implemented `$safe`, `$all`, `$any`, and `$memoize` in `src/utils/functions.js` using the existing HOF invocation conventions.
- Reused the shared diagnostics sanitizer for `$safe` so wrapped failures expose safe fields such as `code`, `message`, `sourceMessage`, `sourceErrorCode`, `status`, `request`, and `operationOutcome` when available.
- Preserved explicit wrapped `sourceMessage` and `sourceErrorCode` in `$safe`, while continuing to sanitize nested request metadata instead of exposing raw nested client/runtime objects.
- Added a stable type-tagged serializer for `$memoize` keys and rejected function- or symbol-valued argument trees with `D3142`.
- Registered `$safe` and `$memoize` with the `<f-:f>` signature form and added the new public HOF registrations.
- Added a narrow adapter in `src/utils/fhirClientWrappers.js` so expression-defined `transform` lambdas inside `$search(..., options)` are converted into JavaScript callbacks before invoking downstream `@outburn/fhir-client`.
- Tightened the mapping parse-error wrapping path so informative parser messages are preserved instead of degrading to `[object Object]` in wrapped `F3002` errors.
- Added focused regression coverage for the new HOFs, `$search` transform exposure, `$first` async short-circuiting, and the informative wrapped mapping parse error path.

## Validation performed

- `npm run mocha -- test/safe-hof.test.js test/all-any-hof.test.js test/memoize-hof.test.js test/search-transform-hof.test.js`
- `npm run mocha -- test/first-hof.test.js test/safe-hof.test.js test/all-any-hof.test.js test/memoize-hof.test.js test/search-transform-hof.test.js`
- Local packaged-client validation through the real `fumifier` -> `@outburn/fhir-client` boundary using a uniquely named `fhir-client` tarball and the public `$search(..., { fetchAll: true, transform: function(...) { ... } })` expression path.
- `npm run build; npx mocha test/safe-hof.test.js --timeout=20000` after the wrapped mapping parse-message fix.

## Compatibility notes

- `$safe`, `$all`, `$any`, and `$memoize` are additive public API features.
- `$memoize` now rejects function-valued and symbol-valued argument trees instead of attempting unstable cache keys.
- `$all(undefined, predicate)` and `$any(undefined, predicate)` follow the documented empty-collection semantics.
- `$search` users adopting `transform` inherit the downstream `@outburn/fhir-client` contract: the option is only valid with `fetchAll: true`, and `maxResults` still counts raw fetched resources before transform filtering.
- Wrapped error consumers should rely on the stable safe fields rather than any raw nested error object.