### PR TITLE
Fix/diagnostic helpers position metadata

### DIFF
--- a/draft-release-notes-diagnostic-helper-metadata.md
+++ b/draft-release-notes-diagnostic-helper-metadata.md
@@ -1,0 +1,9 @@
+# Draft Release Notes: Diagnostic Helper Metadata
+
+`fumifier` now preserves stable execution IDs and helper source-location metadata in verbose diagnostics emitted by `$warn`, `$info`, and `$trace`.
+
+This fixes cases where helper-generated diagnostic entries could show `executionId: 'unknown'`, especially when the helper ran from a derived frame such as a nested function call or block scope.
+
+Verbose helper diagnostics now also include the helper call-site `position`, `start`, and `line` fields again, making it easier to trace warnings and debug entries back to the expression source that emitted them.
+
+This is a bug-fix level change. Helper diagnostic codes, buckets, messages, log behavior, and `$trace` return semantics are unchanged.

--- a/src/fumifier.js
+++ b/src/fumifier.js
@@ -1826,9 +1826,20 @@ var fumifier = (function() {
       if (isLambda(proc)) {
         result = await applyProcedure(proc, validatedArgs);
       } else if (proc && proc._fumifier_function === true) {
+        var executionId = typeof environment.lookup === 'function' ? environment.lookup('executionId') : undefined;
+        if (typeof executionId === 'undefined') {
+          executionId = environment.executionId;
+        }
         var focus = {
           environment: environment,
-          input: input
+          input: input,
+          executionId: executionId,
+          callSite: {
+            position: proc.position,
+            start: proc.start,
+            line: proc.line,
+            token: proc.token
+          }
         };
         // the `focus` is passed in as the `this` for the invoked function
         result = proc.implementation.apply(focus, validatedArgs);
@@ -2372,13 +2383,16 @@ var fumifier = (function() {
         // error parsing the mapping expression - customize error format for mapping context
         const nestedParseError = parseError.error || parseError;
         populateMessage(nestedParseError, this.environment);
-        const sourceMessage = typeof nestedParseError.message === 'string'
-          ? nestedParseError.message
-          : typeof parseError.message === 'string'
-            ? parseError.message
-            : typeof parseError.value === 'string'
-              ? parseError.value
-              : String(nestedParseError);
+        let sourceMessage;
+        if (typeof nestedParseError.message === 'string') {
+          sourceMessage = nestedParseError.message;
+        } else if (typeof parseError.message === 'string') {
+          sourceMessage = parseError.message;
+        } else if (typeof parseError.value === 'string') {
+          sourceMessage = parseError.value;
+        } else {
+          sourceMessage = String(nestedParseError);
+        }
         throw attachSourceErrorMetadata({
           code: "F3002",
           value: mappingKey,

--- a/src/fumifier.js
+++ b/src/fumifier.js
@@ -2455,16 +2455,73 @@ var fumifier = (function() {
 
   // Register user-facing logging functions
   (function registerLoggingFunctions(frame) {
+    /**
+     * Resolve the active execution ID for a helper invocation.
+     * @param {{ executionId?: string, environment: { lookup?: Function, executionId?: string } }} context - Helper invocation context
+     * @returns {string} Execution ID for the active evaluation
+     */
+    function resolveHelperExecutionId(context) {
+      if (typeof context.executionId !== 'undefined') {
+        return context.executionId;
+      }
+
+      const env = context.environment;
+      if (typeof env.lookup === 'function') {
+        const lookedUpExecutionId = env.lookup('executionId');
+        if (typeof lookedUpExecutionId !== 'undefined') {
+          return lookedUpExecutionId;
+        }
+      }
+
+      if (typeof env.executionId !== 'undefined') {
+        return env.executionId;
+      }
+
+      return 'unknown';
+    }
+
+    /**
+     * Build a diagnostic entry for a logging helper invocation.
+     * @param {{ executionId?: string, environment: Object, callSite?: { position?: number, start?: number, line?: number } }} context - Helper invocation context
+     * @param {string} code - Diagnostic code
+     * @param {string} message - Diagnostic message
+     * @param {Object} [extraFields] - Additional fields to copy onto the entry
+     * @returns {Object} Diagnostic entry ready for collection
+     */
+    function buildHelperDiagnosticEntry(context, code, message, extraFields) {
+      const entry = {
+        code,
+        message,
+        executionId: resolveHelperExecutionId(context)
+      };
+
+      if (extraFields) {
+        Object.assign(entry, extraFields);
+      }
+
+      const callSite = context.callSite || {};
+      if (Number.isFinite(callSite.position)) {
+        entry.position = callSite.position;
+      }
+      if (Number.isFinite(callSite.start)) {
+        entry.start = callSite.start;
+      }
+      if (Number.isFinite(callSite.line)) {
+        entry.line = callSite.line;
+      }
+
+      return entry;
+    }
+
     // $warn(message) -> F5320
     var warnImpl = defineFunction(function(message) {
       const msg = fn.string(message);
       const env = this.environment;
-      const execId = env.executionId || 'unknown';
-      const entry = { code: 'F5320', message: msg, executionId: execId };
+      const entry = buildHelperDiagnosticEntry(this, 'F5320', msg);
       const act = decide(entry.code, env);
       if (act.shouldLog) {
         const logger = env.lookup(SYM.logger) || createDefaultLogger();
-        logger.warn(`[${execId}] ${msg}`);
+        logger.warn(`[${entry.executionId}] ${msg}`);
       }
       push(env, entry);
       return undefined;
@@ -2476,12 +2533,11 @@ var fumifier = (function() {
     frame.bind('info', defineFunction(function(message) {
       const msg = fn.string(message);
       const env = this.environment;
-      const execId = env.executionId || 'unknown';
-      const entry = { code: 'F5500', message: msg, executionId: execId };
+      const entry = buildHelperDiagnosticEntry(this, 'F5500', msg);
       const act = decide(entry.code, env);
       if (act.shouldLog) {
         const logger = env.lookup(SYM.logger) || createDefaultLogger();
-        logger.info(`[${execId}] ${msg}`);
+        logger.info(`[${entry.executionId}] ${msg}`);
       }
       push(env, entry);
       return undefined;
@@ -2493,13 +2549,12 @@ var fumifier = (function() {
       const val = value;
       const lbl = fn.string(label);
       const proj = (typeof projection === 'undefined') ? val : projection;
-      const execId = env.executionId || 'unknown';
       const msg = `${lbl}: ${fn.string(proj)}`;
-      const entry = { code: 'F5600', message: msg, label: lbl, value: val, executionId: execId };
+      const entry = buildHelperDiagnosticEntry(this, 'F5600', msg, { label: lbl, value: val });
       const act = decide(entry.code, env);
       if (act.shouldLog) {
         const logger = env.lookup(SYM.logger) || createDefaultLogger();
-        logger.debug(`[${execId}] ${msg}`);
+        logger.debug(`[${entry.executionId}] ${msg}`);
       }
       push(env, entry);
       return val;

--- a/test/debug.js
+++ b/test/debug.js
@@ -124,24 +124,30 @@ void async function () {
 // * severity.coding.code = '255604002'
 
 
-[(
-  InstanceOf: Patient
-  * communication
-    * language
-      * coding
-        * system = 'http://acme.org.il/code/lang'
-        * code = 'en'
-      * coding
-        * system = null
-),(
-  InstanceOf: Patient
-  * communication
-    * language
-      * coding
-        * system = 'http://acme.org.il/code/lang'
-        * code = 'fr'
-      * coding
-)]
+// [(
+//   InstanceOf: Patient
+//   * communication
+//     * language
+//       * coding
+//         * system = 'http://acme.org.il/code/lang'
+//         * code = 'en'
+//       * coding
+//         * system = null
+// ),(
+//   InstanceOf: Patient
+//   * communication
+//     * language
+//       * coding
+//         * system = 'http://acme.org.il/code/lang'
+//         * code = 'fr'
+//       * coding
+// )]
+
+
+$info('abc');
+{}.$trace('abc');
+$warn('abc');
+
 `
 ;
 
@@ -181,7 +187,7 @@ void async function () {
 
   try {
     expr.setLogger(console);
-    res = await expr.evaluate(
+    res = await expr.evaluateVerbose(
       {
         resourceType: "Patient"
       },

--- a/test/diagnostic-helper-metadata.test.js
+++ b/test/diagnostic-helper-metadata.test.js
@@ -1,0 +1,117 @@
+import { expect } from 'chai';
+import fumifier from '../src/fumifier.js';
+
+function getProcedureName(node) {
+  if (!node || node.type !== 'function' || !node.procedure) {
+    return null;
+  }
+
+  if (node.procedure.type === 'variable') {
+    return node.procedure.value;
+  }
+
+  if (node.procedure.type === 'path' && Array.isArray(node.procedure.steps) && node.procedure.steps.length > 0) {
+    return node.procedure.steps[0].value;
+  }
+
+  return null;
+}
+
+function collectFunctionLines(value, linesByName = {}) {
+  if (!value || typeof value !== 'object') {
+    return linesByName;
+  }
+
+  if (Array.isArray(value)) {
+    value.forEach(item => collectFunctionLines(item, linesByName));
+    return linesByName;
+  }
+
+  const procedureName = getProcedureName(value);
+  if (procedureName) {
+    if (!linesByName[procedureName]) {
+      linesByName[procedureName] = [];
+    }
+    linesByName[procedureName].push(value.line);
+  }
+
+  Object.values(value).forEach(candidate => collectFunctionLines(candidate, linesByName));
+  return linesByName;
+}
+
+function expectDiagnosticMetadata(entry, executionId, line) {
+  expect(entry.executionId).to.equal(executionId);
+  expect(entry.position).to.be.a('number');
+  expect(entry.start).to.be.a('number');
+  expect(entry.line).to.equal(line);
+}
+
+function expectDiagnosticMetadataPresence(entry, executionId) {
+  expect(entry.executionId).to.equal(executionId);
+  expect(entry.position).to.be.a('number');
+  expect(entry.start).to.be.a('number');
+  expect(entry.line).to.be.a('number');
+}
+
+describe('Diagnostic Helper Metadata', () => {
+  it('should include executionId and source metadata for direct helper diagnostics', async () => {
+    const compiled = await fumifier(`(
+  $info("info message");
+  $trace({"kind":"trace"}, "trace_label");
+  $warn("warn message")
+)`);
+
+    const report = await compiled.evaluateVerbose({});
+    const linesByName = collectFunctionLines(compiled.ast());
+
+    expect(report.executionId).to.be.a('string');
+    expect(report.diagnostics.warning).to.have.length(1);
+    expect(report.diagnostics.debug).to.have.length(2);
+
+    const warningEntry = report.diagnostics.warning[0];
+    const infoEntry = report.diagnostics.debug.find(entry => entry.code === 'F5500');
+    const traceEntry = report.diagnostics.debug.find(entry => entry.code === 'F5600');
+
+    expect(infoEntry).to.not.equal(undefined);
+    expect(traceEntry).to.not.equal(undefined);
+
+    expectDiagnosticMetadata(infoEntry, report.executionId, linesByName.info[0]);
+    expectDiagnosticMetadata(traceEntry, report.executionId, linesByName.trace[0]);
+    expectDiagnosticMetadata(warningEntry, report.executionId, linesByName.warn[0]);
+
+    expect(infoEntry.message).to.equal('info message');
+    expect(traceEntry.message).to.equal('trace_label: {"kind":"trace"}');
+    expect(traceEntry.label).to.equal('trace_label');
+    expect(traceEntry.value).to.deep.equal({ kind: 'trace' });
+    expect(warningEntry.message).to.equal('warn message');
+    expect(report.result).to.equal(undefined);
+  });
+
+  it('should preserve executionId metadata for helpers invoked in nested frames', async () => {
+    const compiled = await fumifier(`(
+  $emitWarning := function($message) {
+    $warn($message)
+  };
+  $emitInfo := function($message) {
+    $info($message)
+  };
+  [
+    $emitWarning("nested warning"),
+    $emitInfo("nested info")
+  ]
+)`);
+
+    const report = await compiled.evaluateVerbose({});
+    expect(report.executionId).to.be.a('string');
+    expect(report.diagnostics.warning).to.have.length(1);
+    expect(report.diagnostics.debug).to.have.length(1);
+
+    const nestedWarning = report.diagnostics.warning[0];
+    const nestedInfo = report.diagnostics.debug[0];
+
+    expectDiagnosticMetadataPresence(nestedWarning, report.executionId);
+    expectDiagnosticMetadataPresence(nestedInfo, report.executionId);
+    expect(nestedWarning.message).to.equal('nested warning');
+    expect(nestedInfo.message).to.equal('nested info');
+  });
+});


### PR DESCRIPTION
## Summary

This change fixes verbose diagnostics emitted by `$warn`, `$info`, and `$trace` so they consistently carry the active evaluation `executionId` and helper call-site source metadata.

## User-visible bug

Before this change, helper-generated diagnostic entries could lose execution metadata in derived frames and fall back to `executionId: 'unknown'`. Helper entries also did not reliably include the helper call-site `position`, `start`, and `line` fields in verbose output.

## Root cause

The helpers were building diagnostic entries from an incomplete invocation context. Fumifier functions were invoked with a `this` context that exposed `environment` and `input`, but not a resolved execution ID or the current helper call-site metadata.

## Fix

- Extended the fumifier-function invocation context in `src/fumifier.js` so helper implementations receive:
  - `executionId`, resolved from the active evaluation frame
  - `callSite`, containing `position`, `start`, `line`, and `token`
- Reworked the `$warn`, `$info`, and `$trace` implementations to build diagnostic entries from that invocation context instead of reading `this.environment.executionId` directly.
- Preserved existing helper codes, buckets, messages, logger thresholds, and `$trace` return behavior.

## Regression coverage

- Added `test/diagnostic-helper-metadata.test.js` as a source-backed regression suite.
- Covered a direct mixed-helper expression and asserted:
  - per-entry `executionId` matches the root verbose `executionId`
  - direct helper diagnostics carry source metadata
  - helper codes still land in the expected buckets
- Covered a nested-frame scenario to verify helper diagnostics no longer depend on `environment.executionId` being a direct property.

## Validation

- `npx mocha test/diagnostic-helper-metadata.test.js --timeout=20000`
  - Passed: 2 tests passing
- `npm run build`
  - Completed successfully
- `npx mocha test/execution-id.test.js --timeout=20000`
  - Passed: 9 tests passing

## Notes

- No public `evaluate()` or `evaluateVerbose()` response shapes were changed.
- The helper invocation context was extended additively, which means user-registered fumifier functions can also observe the new metadata on `this`.