### PR TITLE
Fix/function error position

### DIFF
--- a/draft-release-notes-function-error-spans.md
+++ b/draft-release-notes-function-error-spans.md
@@ -1,0 +1,9 @@
+# Draft Release Notes: Function Error Spans
+
+`fumifier` now preserves the full function call-head span for runtime function-validation diagnostics, including both contextual signature failures and direct argument-type validation failures.
+
+This fixes cases where function-call errors such as `T0411` and `T0410` could report `start` at the opening parenthesis instead of the function name, or drop `start: 0` entirely when the call began at the start of an expression.
+
+Verbose diagnostics for function invocation now consistently anchor to the callee span, making it easier to highlight and trace invalid calls such as `$search(...)` and other registered helper or user-defined function invocations.
+
+This is a bug-fix level change. Error codes, signature validation behavior, and function execution semantics are unchanged; only the reported source metadata for these diagnostics has been corrected.

--- a/src/fumifier.js
+++ b/src/fumifier.js
@@ -1756,15 +1756,15 @@ var fumifier = (function() {
       if(typeof proc === 'object') {
         proc.token = procName;
         proc.position = expr.position;
-        proc.start = expr.start;
+        proc.start = typeof expr.procedure?.start === 'number' ? expr.procedure.start : expr.start;
         proc.line = expr.line;
       }
       result = await apply(proc, evaluatedArgs, input, environment);
     } catch (err) {
-      if(!err.position) {
+      if(!Number.isFinite(err.position)) {
         // add the position field to the error
         err.position = expr.position;
-        err.start = expr.start;
+        err.start = typeof expr.procedure?.start === 'number' ? expr.procedure.start : expr.start;
         err.line = expr.line;
       }
       if (!err.token) {
@@ -1871,9 +1871,15 @@ var fumifier = (function() {
         if (typeof err.token === 'undefined' && typeof proc.token !== 'undefined') {
           err.token = proc.token;
         }
-        err.position = proc.position || err.position;
-        err.start = proc.start || err.start;
-        err.line = proc.line || err.line;
+        if (Number.isFinite(proc.position)) {
+          err.position = proc.position;
+        }
+        if (Number.isFinite(proc.start)) {
+          err.start = proc.start;
+        }
+        if (Number.isFinite(proc.line)) {
+          err.line = proc.line;
+        }
       }
       throw err;
     }

--- a/test/debug.js
+++ b/test/debug.js
@@ -5,9 +5,10 @@ import fumifier from '../src/fumifier.js';
 import { FhirSnapshotGenerator } from 'fhir-snapshot-generator';
 import { FhirStructureNavigator } from '@outburn/structure-navigator';
 import { FhirPackageExplorer } from 'fhir-package-explorer';
+import { FhirTerminologyRuntime } from 'fhir-terminology-runtime';
 
 // var context = ['il.core.fhir.r4#0.21.0', 'fumifier.test.pkg#0.1.0'];
-var context = ['il.szmc.fhir.r4#0.3.3'];
+var context = ['il.tasmc.fhir.r4#0.9.5'];
 
 void async function () {
   // Create shared FhirPackageExplorer instance
@@ -23,132 +24,14 @@ void async function () {
   var generator = await FhirSnapshotGenerator.create({ fpe, fhirVersion: '4.0.1', cacheMode: 'lazy' });
   var navigator = new FhirStructureNavigator(generator);
 
-  var expression = `
-// InstanceOf: dual-assignment-test-profile
-// * name
-//   * given = 'John'
-//   * family = 'Doe'
-// // should create a single entry in identifier array
-// // should include system, value, and use
-// // since the TestSlice is max=1
-// * identifier[TestSlice].value = '12345'
-// * identifier[TestSlice].use = 'official'
+  var ftr = await FhirTerminologyRuntime.create({ fpe });
 
-
-
-// (InstanceOf: ILHDPCondition
-// * identifier
-//   * system = 'urn:ietf:rfc:3986'
-//   * value = 'urn:uuid:550e8400-e29b-41d4-a716-446655440000'
-// * category.coding.code = 'problem-list-item'
-// * code.text = 'Diabetes mellitus type 2'
-// * subject.reference = 'Patient/12345'
-// * recordedDate = '2024-06-01T10:00:00Z'
-// * recorder.display = 'Dr. Jane Smith'
-// * severity.coding.code = '255604002');
-// $trace('additional info');
-
-// InstanceOf: il-core-patient
-// * identifier[il-id].value = '123'
-// * name
-//   * given = 'John'
-//   * family = 'Doe'
-// * gender = 'unknown'
-// * birthDate = '1985'
-// * address.extension[language].value = 'en'
-
-
-// * maritalStatus.coding.code = 'UNK'
-// * address.city.extension[cityCode].value.coding.code = '4000'
-
-// InstanceOf: TestSliceValidation
-// * status = 'unknown'
-// * code.coding[OptionalSlice]
-
-// Instance: '123'
-// InstanceOf: TestSliceValidation
-// $a := 'b'
-// * status = 'unknown'; 
-// * code.coding[MandatorySlice].display = $a;
-// $a := 'b';
-
-// $mapping1('other');
-
-// InstanceOf: bp
-// * component[SystolicBP].value = 120
-// * component[DiastolicBP].value = 80
-// * status = 'final'
-// * subject.reference = 'Patient/12345'
-// * effectiveDateTime = '2020-01-01T12:00:00Z'
-
-
-
-// InstanceOf: bp
-// * status = 'final'
-// * subject.reference = 'Patient/123'
-// * effectiveDateTime = '2023-10-01T00:00:00Z'
-// * component[SystolicBP].value.value = '120.00'
-// * component[DiastolicBP].value.value = '80.00'
-
-  // * extension[ext-il-hmo].value.coding
-  //   * code = '101-nope'
-  // * display = 'Custom HMO Name'
-
-
-// InstanceOf: ILHDPCondition
-// * identifier.value = 'COND-001'
-// * category.coding
-//   * system = "http://terminology.hl7.org/CodeSystem/condition-category"
-//   * code = "encounter-diagnosis"
-//   * display = "Encounter Diagnosis"
-// * code.text = "Hypertension"
-// * subject.reference = "Patient/12345"
-// * recordedDate = "2023-01-15T08:00:00Z"
-// * recorder.display = "Dr. Alice Smith"
-// * severity.coding
-
-
-// InstanceOf: SZMCCondition
-// * identifier
-//   * system = 'urn:ietf:rfc:3986'
-//   * value = 'urn:uuid:550e8400-e29b-41d4-a716-446655440000'
-// * id = 'abc123'
-// * clinicalStatus
-//   * coding.code = 'active'
-//   * coding[szmc].code = '2'
-// * category.coding.code = 'problem-list-item'
-// * code.text = 'Diabetes mellitus type 2'
-// * subject.reference = 'Patient/12345'
-// * recordedDate = '2024-06-01T10:00:00Z'
-// * recorder.display = 'Dr. Jane Smith'
-// * severity.coding.code = '255604002'
-
-
-// [(
-//   InstanceOf: Patient
-//   * communication
-//     * language
-//       * coding
-//         * system = 'http://acme.org.il/code/lang'
-//         * code = 'en'
-//       * coding
-//         * system = null
-// ),(
-//   InstanceOf: Patient
-//   * communication
-//     * language
-//       * coding
-//         * system = 'http://acme.org.il/code/lang'
-//         * code = 'fr'
-//       * coding
-// )]
-
-
-$info('abc');
-{}.$trace('abc');
-$warn('abc');
-
-`
+  var expression = `// line 1
+  // line 2
+  // line 3
+  // line 4
+          $search($, params)
+  `
 ;
 
   console.log('Starting debug script...');
@@ -174,7 +57,8 @@ $warn('abc');
     console.log('Compiling expression...');
     expr = await fumifier(expression, {
       navigator,
-      mappingCache
+      mappingCache,
+      terminologyRuntime: ftr
     });
     console.log('Expression compiled successfully');
   } catch (e) {
@@ -189,7 +73,16 @@ $warn('abc');
     expr.setLogger(console);
     res = await expr.evaluateVerbose(
       {
-        resourceType: "Patient"
+        "encounter_adm_id": "adm-111",
+        "followUp_medical_record": "fol-111",
+        "release_medical_record": "rel-111",
+        "record_type": "6",
+        "release_date": "2026-01-29",
+        "unit": "10038",
+        "subject": "6105942",
+        "admission_entry_date": "2026-01-25",
+        "unit_satellite": "102",
+        "encounter_id": "13705968"
       },
       {
         // logLevel: 50,

--- a/test/function-error-spans.test.js
+++ b/test/function-error-spans.test.js
@@ -1,0 +1,46 @@
+import { expect } from 'chai';
+import fumifier from '../src/fumifier.js';
+
+describe('Function Error Spans', () => {
+  it('should anchor contextual signature errors to the call head span', async () => {
+    const compiled = await fumifier('$foo($, params)');
+    compiled.registerFunction('foo', function(resourceType, params, options) {
+      return { resourceType, params, options };
+    }, '<s-o?o?:x>');
+
+    const report = await compiled.evaluateVerbose({ id: 'example' });
+    const diagnostic = report.diagnostics.error[0];
+
+    expect(report.ok).to.equal(false);
+    expect(report.diagnostics.error).to.have.length(1);
+    expect(diagnostic).to.include({
+      code: 'T0411',
+      token: 'foo',
+      index: 1,
+      line: 1,
+      start: 0,
+      position: 5
+    });
+  });
+
+  it('should anchor direct argument validation errors to the call head span', async () => {
+    const compiled = await fumifier('$foo($, params)');
+    compiled.registerFunction('foo', function(resourceType, params) {
+      return { resourceType, params };
+    }, '<so?:x>');
+
+    const report = await compiled.evaluateVerbose({ id: 'example' });
+    const diagnostic = report.diagnostics.error[0];
+
+    expect(report.ok).to.equal(false);
+    expect(report.diagnostics.error).to.have.length(1);
+    expect(diagnostic).to.include({
+      code: 'T0410',
+      token: 'foo',
+      index: 1,
+      line: 1,
+      start: 0,
+      position: 5
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fix function-call diagnostic source metadata so validation errors anchor to the function call head instead of collapsing onto the opening parenthesis.

Resolves #100 

## Root Cause

Function-call errors were inheriting `position` and `start` from the enclosing call node, while the parser already had a more precise callee span on `expr.procedure`. In addition, zero-valued offsets such as `start: 0` could be dropped by truthy fallback logic during error propagation.

## Changes

- Use the callee span start (`expr.procedure.start`) when attaching function-call diagnostic metadata.
- Preserve zero-valued offsets by switching function error propagation from truthy fallbacks to explicit numeric checks.
- Keep function-call diagnostics anchored consistently for both:
  - contextual signature failures such as `T0411`
  - direct argument validation failures such as `T0410`
- Add focused regression coverage for both signature shapes.

## Testing

- `npm run debug:detached`
- `npx mocha test/function-error-spans.test.js --timeout=20000`