### PR TITLE
Fix/date accepts numbers

### DIFF
--- a/draft-release-notes-date-like-epoch-millis.md
+++ b/draft-release-notes-date-like-epoch-millis.md
@@ -1,0 +1,31 @@
+# Draft Release Notes: Epoch-Millis Support for Date-Like FHIR Primitives
+
+`fumifier` now canonicalizes runtime numeric assignments to FHIR `date`, `dateTime`, and `instant` primitives as UTC epoch-millis values instead of falling back to generic string conversion.
+
+## Highlights
+
+- Numeric inputs for `date`, `dateTime`, and `instant` now go through the date-like canonicalization path instead of being emitted as stringified numbers.
+- Valid finite epoch-millis values now produce canonical UTC FHIR output:
+  - `date` -> `YYYY-MM-DD`
+  - `dateTime` -> `YYYY-MM-DDTHH:mm:ss.SSSZ`
+  - `instant` -> `YYYY-MM-DDTHH:mm:ss.SSSZ`
+- Invalid numeric values, including non-finite numbers and epoch-millis values outside the supported JavaScript `Date` range, now surface the existing `F5111` validation behavior instead of leaking into output as plain strings.
+
+## User-Visible Corrections
+
+- Assigning `0` to `Patient.birthDate` now yields `1970-01-01`.
+- Assigning `0` to `Patient.deceasedDateTime` now yields `1970-01-01T00:00:00.000Z`.
+- Assigning `0` to `Observation.issued` now yields `1970-01-01T00:00:00.000Z`.
+- Oversized numeric literals that were previously stringified into output are now rejected through `F5111`.
+
+## Notes for Integrators
+
+- This change only affects runtime JavaScript `number` inputs assigned to FHIR `date`, `dateTime`, and `instant` primitives.
+- Existing string-based date-like behavior is unchanged, including precision preservation for year-only and year-month inputs.
+- No public API signatures changed.
+
+## Validation Summary
+
+- FLASH fixture coverage was added for valid numeric canonicalization and out-of-range `F5111` handling.
+- The FLASH-only regression suite passed after rebuild.
+- The verbose-policy regression suite passed with the new `F5111` case included.

--- a/src/flashEvaluator/DateLikeCanonicalizer.js
+++ b/src/flashEvaluator/DateLikeCanonicalizer.js
@@ -25,9 +25,13 @@ const RE_TZ_CAPTURE = /([+-]\d{2}):(\d{2})$/;
 const RE_YEAR_ONLY = /^\d{4}$/;
 const RE_YEAR_MONTH = /^\d{4}-\d{2}$/;
 const RE_T_24 = /T24:/;
+const MAX_EPOCH_MILLIS = 8640000000000000;
+const UTC_TIMEZONE = '0000';
+const DATE_PICTURE = '[Y0001]-[M01]-[D01]';
+const UTC_TIMESTAMP_PICTURE = '[Y0001]-[M01]-[D01]T[H01]:[m01]:[s01].[f001][Z01:01t]';
 
 /**
- * Canonicalize a date-like primitive string according to FHIR + JSONata datetime semantics.
+ * Canonicalize a date-like primitive value according to FHIR + JSONata datetime semantics.
  * Handles: date | dateTime | instant
  *
  * Behavior:
@@ -39,7 +43,7 @@ const RE_T_24 = /T24:/;
  * - Throws via policy.enforce when applicable
  *
  * @param {Object} expr - Expression with FHIR context
- * @param {string} inputStr - Raw input string
+ * @param {string|number} inputValue - Raw input value
  * @param {string} fhirTypeCode - One of 'date' | 'dateTime' | 'instant'
  * @param {string} elementFlashPath - For error reporting
  * @param {Object} environment - Execution environment
@@ -70,15 +74,27 @@ export default class DateLikeCanonicalizer {
   /**
    * Canonicalize a FHIR date-like primitive value.
    * @param {Object} expr Expression with FHIR context for error reporting
-   * @param {string} inputStr Input value to canonicalize
+  * @param {string|number} inputValue Input value to canonicalize
    * @param {('date'|'dateTime'|'instant')} fhirTypeCode The FHIR type code
    * @param {string} elementFlashPath Element flash path for diagnostics
    * @param {Object} environment Execution environment (used by jsonata datetime)
    * @param {Object} policy Active validation policy
    * @returns {string} Canonicalized value (or original when downgraded/inhibited)
    */
-  static canonicalize(expr, inputStr, fhirTypeCode, elementFlashPath, environment, policy) {
-    const originalStr = fn.string(inputStr);
+  static canonicalize(expr, inputValue, fhirTypeCode, elementFlashPath, environment, policy) {
+    const originalStr = fn.string(inputValue);
+
+    if (typeof inputValue === 'number') {
+      if (!Number.isFinite(inputValue) || Math.abs(inputValue) > MAX_EPOCH_MILLIS || Number.isNaN(new Date(inputValue).valueOf())) {
+        return this._createF5111ErrorOrDowngrade(expr, originalStr, elementFlashPath, fhirTypeCode, policy);
+      }
+
+      if (fhirTypeCode === 'date') {
+        return dateTime.fromMillis(inputValue, DATE_PICTURE, UTC_TIMEZONE);
+      }
+
+      return dateTime.fromMillis(inputValue, UTC_TIMESTAMP_PICTURE, UTC_TIMEZONE);
+    }
 
     // If regex-band validation is inhibited entirely, keep original value (no parsing, no truncation)
     if (!policy.shouldValidate('F5110')) {

--- a/src/flashEvaluator/DateLikeCanonicalizer.js
+++ b/src/flashEvaluator/DateLikeCanonicalizer.js
@@ -74,7 +74,7 @@ export default class DateLikeCanonicalizer {
   /**
    * Canonicalize a FHIR date-like primitive value.
    * @param {Object} expr Expression with FHIR context for error reporting
-  * @param {string|number} inputValue Input value to canonicalize
+   * @param {string|number} inputValue Input value to canonicalize
    * @param {('date'|'dateTime'|'instant')} fhirTypeCode The FHIR type code
    * @param {string} elementFlashPath Element flash path for diagnostics
    * @param {Object} environment Execution environment (used by jsonata datetime)
@@ -85,7 +85,7 @@ export default class DateLikeCanonicalizer {
     const originalStr = fn.string(inputValue);
 
     if (typeof inputValue === 'number') {
-      if (!Number.isFinite(inputValue) || Math.abs(inputValue) > MAX_EPOCH_MILLIS || Number.isNaN(new Date(inputValue).valueOf())) {
+      if (!Number.isFinite(inputValue) || Math.abs(inputValue) > MAX_EPOCH_MILLIS) {
         return this._createF5111ErrorOrDowngrade(expr, originalStr, elementFlashPath, fhirTypeCode, policy);
       }
 

--- a/src/flashEvaluator/PrimitiveValidator.js
+++ b/src/flashEvaluator/PrimitiveValidator.js
@@ -69,7 +69,8 @@ export default class PrimitiveValidator {
 
     // Route: date-like canonicalization
     const isDateLike = fhirTypeCode === 'date' || fhirTypeCode === 'dateTime' || fhirTypeCode === 'instant';
-    if (isDateLike && valueType === 'string') {
+    const isDateLikeInputType = valueType === 'string' || valueType === 'number';
+    if (isDateLike && isDateLikeInputType) {
       return DateLikeCanonicalizer.canonicalize(
         expr,
         input,

--- a/test/test-suite/groups/flash-evaluate/flash-eval-epoch-millis-date.fume
+++ b/test/test-suite/groups/flash-evaluate/flash-eval-epoch-millis-date.fume
@@ -1,0 +1,2 @@
+(InstanceOf: Patient
+* birthDate = 0).birthDate

--- a/test/test-suite/groups/flash-evaluate/flash-eval-epoch-millis-date.json
+++ b/test/test-suite/groups/flash-evaluate/flash-eval-epoch-millis-date.json
@@ -1,0 +1,8 @@
+{
+  "skip": false,
+  "description": "Assignment of epoch millis into Patient.birthDate - should canonicalize to UTC date",
+  "data": {},
+  "bindings": {},
+  "result": "1970-01-01",
+  "expr-file": "flash-eval-epoch-millis-date.fume"
+}

--- a/test/test-suite/groups/flash-evaluate/flash-eval-epoch-millis-datetime.fume
+++ b/test/test-suite/groups/flash-evaluate/flash-eval-epoch-millis-datetime.fume
@@ -1,0 +1,2 @@
+(InstanceOf: Patient
+* deceasedDateTime = 0).deceasedDateTime

--- a/test/test-suite/groups/flash-evaluate/flash-eval-epoch-millis-datetime.json
+++ b/test/test-suite/groups/flash-evaluate/flash-eval-epoch-millis-datetime.json
@@ -1,0 +1,8 @@
+{
+  "skip": false,
+  "description": "Assignment of epoch millis into Patient.deceasedDateTime - should canonicalize to UTC dateTime",
+  "data": {},
+  "bindings": {},
+  "result": "1970-01-01T00:00:00.000Z",
+  "expr-file": "flash-eval-epoch-millis-datetime.fume"
+}

--- a/test/test-suite/groups/flash-evaluate/flash-eval-epoch-millis-instant.fume
+++ b/test/test-suite/groups/flash-evaluate/flash-eval-epoch-millis-instant.fume
@@ -1,0 +1,4 @@
+(InstanceOf: Observation
+* status = 'final'
+* code.text = 'abc'
+* issued = 0).issued

--- a/test/test-suite/groups/flash-evaluate/flash-eval-epoch-millis-instant.json
+++ b/test/test-suite/groups/flash-evaluate/flash-eval-epoch-millis-instant.json
@@ -1,0 +1,8 @@
+{
+  "skip": false,
+  "description": "Assignment of epoch millis into Observation.issued - should canonicalize to UTC instant",
+  "data": {},
+  "bindings": {},
+  "result": "1970-01-01T00:00:00.000Z",
+  "expr-file": "flash-eval-epoch-millis-instant.fume"
+}

--- a/test/test-suite/groups/flash-evaluate/flash-eval-error-epoch-millis-range.fume
+++ b/test/test-suite/groups/flash-evaluate/flash-eval-error-epoch-millis-range.fume
@@ -1,0 +1,2 @@
+(InstanceOf: Patient
+* birthDate = 8640000000000001).birthDate

--- a/test/test-suite/groups/flash-evaluate/flash-eval-error-epoch-millis-range.json
+++ b/test/test-suite/groups/flash-evaluate/flash-eval-error-epoch-millis-range.json
@@ -1,0 +1,8 @@
+{
+  "skip": false,
+  "description": "Out-of-range epoch millis assigned into Patient.birthDate - must raise F5111",
+  "data": {},
+  "bindings": {},
+  "code": "F5111",
+  "expr-file": "flash-eval-error-epoch-millis-range.fume"
+}


### PR DESCRIPTION
## Summary

Add epoch-millis support for FHIR date-like primitives.

Numeric runtime assignments to `date`, `dateTime`, and `instant` now flow through the date-like canonicalization path instead of falling back to generic string conversion. Valid finite epoch-millis values are canonicalized in UTC, and invalid numeric values now surface the existing `F5111` validation behavior.

Resolves #82 

## Changes

- Route numeric `date`, `dateTime`, and `instant` inputs through `DateLikeCanonicalizer`
- Canonicalize valid epoch-millis numbers to UTC FHIR strings
- Reject non-finite and out-of-range numeric date-like values with `F5111`
- Add shared FLASH fixture coverage for:
  - `Patient.birthDate = 0`
  - `Patient.deceasedDateTime = 0`
  - `Observation.issued = 0`
  - out-of-range numeric rejection via `F5111`
- Add a root-level draft release note for the feature

## Behavior

- `date` numeric input now emits `YYYY-MM-DD`
- `dateTime` numeric input now emits `YYYY-MM-DDTHH:mm:ss.SSSZ`
- `instant` numeric input now emits `YYYY-MM-DDTHH:mm:ss.SSSZ`
- Existing string-based date-like precision behavior remains unchanged

## Validation

- `npm run build`
- `npx mocha test/run-test-suite.test.js --timeout=20000 -- --flash-only`
- `npx mocha test/verbose-policy.test.js --timeout=20000`
- `npx mocha test/run-test-suite.test.js --timeout=20000 --grep "epoch millis" -- --flash-only`