### PR TITLE
Feat/enhance right now

### DIFF
--- a/draft-release-notes-right-now-picture-aliases.md
+++ b/draft-release-notes-right-now-picture-aliases.md
@@ -1,0 +1,33 @@
+# Draft Release Notes: Picture Aliases and Formatted `$rightNow()`
+
+`fumifier` now lets `$rightNow()` format the current wall-clock time using the same picture pipeline as `$now()` and `$fromMillis()`, and adds a small set of exact picture aliases for formatting-oriented date/time helpers.
+
+## Highlights
+
+- `$rightNow()` remains backward-compatible with its existing zero-argument behavior and still returns epoch milliseconds when called without arguments.
+- `$rightNow(picture)` and `$rightNow(picture, timezone)` now return formatted strings instead of requiring callers to compose formatting separately.
+- `$now()` and `$fromMillis()` now accept the same exact picture aliases:
+  - `date` -> `YYYY-MM-DD`
+  - `dateTime` -> second-precision timestamp with timezone
+  - `instant` -> millisecond-precision timestamp with timezone
+  - `time` -> `HH:MM:SS.sss`
+
+## User-Visible Changes
+
+- `$rightNow('date')` now returns a calendar date such as `2026-07-14`.
+- `$rightNow('instant')` now returns a full timestamp such as `2026-07-14T12:34:56.789Z`.
+- `$fromMillis(0, 'dateTime')` now returns `1970-01-01T00:00:00Z`.
+- `$fromMillis(0, 'dateTime', '-0500')` now returns `1969-12-31T19:00:00-05:00`.
+
+## Notes for Integrators
+
+- Alias matching is exact and case-sensitive. Only the known keywords are rewritten.
+- Existing raw picture strings are unchanged and still go through the same formatter behavior as before.
+- Alias handling is formatting-only in this change. `$toMillis()` parsing behavior is unchanged.
+- Timezone handling is unchanged; aliases honor the optional timezone argument in the same way as raw pictures.
+
+## Validation Summary
+
+- Added focused implementation coverage for `$rightNow()`, `$now()`, and `$fromMillis()` alias behavior.
+- Rebuilt the package outputs and ran the focused implementation suite.
+- `npx mocha test/implementation-tests.test.js --timeout=20000` passed with `79 passing`.

--- a/src/utils/datetime.js
+++ b/src/utils/datetime.js
@@ -10,6 +10,7 @@ License: See the LICENSE file included with this package for the terms that appl
 */
 
 import utils from './utils.js';
+import resolveFormatPictureAlias from './pictureAliases.js';
 
 /**
  * DateTime formatting and parsing functions
@@ -1349,7 +1350,7 @@ const dateTime = (function () {
       return undefined;
     }
 
-    return formatDateTime.call(this, millis, picture, timezone);
+    return formatDateTime.call(this, millis, resolveFormatPictureAlias(picture), timezone);
   }
 
   return {

--- a/src/utils/functions.js
+++ b/src/utils/functions.js
@@ -11,6 +11,7 @@ License: See the LICENSE file included with this package for the terms that appl
 
 import utils from './utils.js';
 import defineFunction from './defineFunction.js';
+import datetime from './datetime.js';
 import { attachSourceErrorMetadata } from './diagnostics.js';
 import { populateMessage } from './errorCodes.js';
 
@@ -2889,10 +2890,17 @@ const functions = (() => {
   /**
      * Like $millis(), returns the current dateTime in milliseconds,
      * but unlike $millis(), will return a new value in each invokation instead of the registered timestamp
-     * @returns {number} milliseconds since midnight, January 1, 1970 UTC
+     * @param {string} [picture] - optional format picture or alias
+     * @param {string} [timezone] - optional timezone used when formatting
+     * @returns {number|string} milliseconds since midnight, January 1, 1970 UTC or a formatted timestamp
      */
-  function rightNow () {
+  function rightNow (picture, timezone) {
     const now = new Date();
+
+    if (typeof picture !== 'undefined') {
+      return datetime.fromMillis(now.getTime(), picture, timezone);
+    }
+
     return now.getTime();
   }
 

--- a/src/utils/pictureAliases.js
+++ b/src/utils/pictureAliases.js
@@ -1,0 +1,19 @@
+const FORMAT_PICTURE_ALIASES = {
+  date: '[Y0001]-[M01]-[D01]',
+  dateTime: '[Y0001]-[M01]-[D01]T[H01]:[m01]:[s01][Z01:01t]',
+  instant: '[Y0001]-[M01]-[D01]T[H01]:[m01]:[s01].[f001][Z01:01t]',
+  time: '[H01]:[m01]:[s01].[f001]'
+};
+
+/**
+ * Resolves exact format-picture aliases to their underlying picture strings.
+ * @param {string | undefined} picture - Candidate alias or raw picture string.
+ * @returns {string | undefined} The aliased or original picture value.
+ */
+export default function resolveFormatPictureAlias(picture) {
+  if (typeof picture === 'undefined') {
+    return undefined;
+  }
+
+  return FORMAT_PICTURE_ALIASES[picture] ?? picture;
+}

--- a/src/utils/registerNativeFn.js
+++ b/src/utils/registerNativeFn.js
@@ -116,7 +116,7 @@ function registerNativeFn(staticFrame, functionEval) {
   staticFrame.bind('isNumeric', defineFunction(fn.isNumeric, '<j-:b>'));
   staticFrame.bind('stringify', defineFunction(fn.stringify, '<x-b?:s>'));
   staticFrame.bind('wait', defineFunction(fn.wait), '<n->');
-  staticFrame.bind('rightNow', defineFunction(fn.rightNow), '<:n>');
+  staticFrame.bind('rightNow', defineFunction(fn.rightNow), '<s?s?:x>');
   staticFrame.bind('initCapOnce', defineFunction(fn.initCapOnce, '<s-:s>'));
   staticFrame.bind('initCap', defineFunction(fn.initCap, '<s-:s>'));
   staticFrame.bind('uuid', defineFunction(fn.uuid, '<j?:s>'));

--- a/test/implementation-tests.test.js
+++ b/test/implementation-tests.test.js
@@ -174,6 +174,76 @@ describe("Functions with side-effects", () => {
     });
   });
 
+  describe("$rightNow() returns milliseconds since the epoch", function() {
+    it("should return result object", async function() {
+      var expr = await fumifier("$rightNow()");
+      var result = await expr.evaluate(testdata2);
+      expect(result).to.be.a("number");
+      expect(result).to.be.above(1474934400000);
+    });
+  });
+
+  describe("$rightNow() returns different values within an expression", function() {
+    it("should return result object", async function() {
+      var expr = await fumifier('($now := $rightNow(); $wait(10); $now != $rightNow())');
+      var result = await expr.evaluate(testdata2);
+      expect(result).to.equal(true);
+    });
+  });
+
+  describe("$rightNow() returns timestamp with defined format and timezone", function() {
+    it("should return result object", async function() {
+      var expr = await fumifier("$rightNow('[h]:[M01][P] [z]', '-0500')");
+      var result = expr.evaluate(testdata2);
+      expect(result).to.eventually.match(/^\d?\d:\d\d[ap]m GMT-05:00$/);
+    });
+  });
+
+  describe("$rightNow() supports picture aliases", function() {
+    it("should return formatted values for each alias", async function() {
+      var expr = await fumifier('{"date": $rightNow("date"), "dateTime": $rightNow("dateTime"), "instant": $rightNow("instant"), "time": $rightNow("time")}');
+      var result = await expr.evaluate(testdata2);
+      expect(result.date).to.match(/^\d\d\d\d-\d\d-\d\d$/);
+      expect(result.dateTime).to.match(/^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d(?:Z|[+-]\d\d:\d\d)$/);
+      expect(result.instant).to.match(/^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\d(?:Z|[+-]\d\d:\d\d)$/);
+      expect(result.time).to.match(/^\d\d:\d\d:\d\d\.\d\d\d$/);
+    });
+  });
+
+  describe("$now() supports picture aliases", function() {
+    it("should return formatted values for each alias", async function() {
+      var expr = await fumifier('{"date": $now("date"), "dateTime": $now("dateTime"), "instant": $now("instant"), "time": $now("time")}');
+      var result = await expr.evaluate(testdata2);
+      expect(result.date).to.match(/^\d\d\d\d-\d\d-\d\d$/);
+      expect(result.dateTime).to.match(/^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d(?:Z|[+-]\d\d:\d\d)$/);
+      expect(result.instant).to.match(/^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\d(?:Z|[+-]\d\d:\d\d)$/);
+      expect(result.time).to.match(/^\d\d:\d\d:\d\d\.\d\d\d$/);
+    });
+  });
+
+  describe("$fromMillis() supports picture aliases", function() {
+    it("should return deterministic formatted values", async function() {
+      var expr = await fumifier('{"date": $fromMillis(0, "date"), "dateTime": $fromMillis(0, "dateTime"), "instant": $fromMillis(0, "instant"), "time": $fromMillis(0, "time"), "dateTimeTz": $fromMillis(0, "dateTime", "-0500")}');
+      var result = await expr.evaluate(testdata2);
+      var expected = {
+        date: "1970-01-01",
+        dateTime: "1970-01-01T00:00:00Z",
+        instant: "1970-01-01T00:00:00.000Z",
+        time: "00:00:00.000",
+        dateTimeTz: "1969-12-31T19:00:00-05:00"
+      };
+      expect(result).to.deep.equal(expected);
+    });
+  });
+
+  describe("$fromMillis() preserves non-alias raw picture strings", function() {
+    it("should leave raw picture behavior unchanged", async function() {
+      var expr = await fumifier("$fromMillis(0, '[Y0001]-[M01]-[D01]', '-0500')");
+      var result = await expr.evaluate(testdata2);
+      expect(result).to.equal("1969-12-31");
+    });
+  });
+
   describe("$millis() returns milliseconds since the epoch", function() {
     it("should return result object", async function() {
       var expr = await fumifier("$millis()");


### PR DESCRIPTION
## Summary

- add a shared picture-alias resolver for formatting helpers
- let `$rightNow()` preserve its zero-argument epoch-millis behavior while also supporting `$rightNow(picture[, timezone])`
- extend `$now()` and `$fromMillis()` with exact picture aliases: `date`, `dateTime`, `instant`, and `time`
- add focused implementation coverage for `$rightNow()`, `$now()`, and `$fromMillis()` alias behavior
- resolve #71 

## User-Visible Behavior

- `$rightNow()` still returns epoch milliseconds when called without arguments
- `$rightNow('date')` now returns a formatted calendar date string
- `$rightNow('instant')` now returns a millisecond-precision timestamp string
- `$now()` and `$fromMillis()` now accept the same exact picture aliases
- existing raw picture strings and timezone behavior remain unchanged

## Testing

- `npm run build`
- `npx mocha test/implementation-tests.test.js --timeout=20000`