### PR TITLE
Fix/nested block comments

### DIFF
--- a/draft-release-notes-issue-63-nested-block-comments.md
+++ b/draft-release-notes-issue-63-nested-block-comments.md
@@ -1,0 +1,7 @@
+# Draft Release Notes: Issue 63 Nested Block Comments
+
+`fumifier` now skips nested `/* ... */` block comments correctly, so inner comment markers no longer cause the outer comment body to leak into live expression parsing.
+
+This fixes cases where expressions with nested block comments could produce misleading parser or evaluator errors because trailing comment text was being tokenized as real code. Expressions that continue normally after the comment now evaluate normally, and expressions that are still invalid after comment removal now surface the real parser error instead.
+
+This is a bug-fix level change. Public APIs and expression semantics are unchanged outside of corrected comment handling, and unterminated block comments continue to report the existing `S0106` error.

--- a/src/utils/tokenizer.js
+++ b/src/utils/tokenizer.js
@@ -227,9 +227,9 @@ export default function (path) {
     if (currentChar === '/' && path.charAt(position + 1) === '*') {
       position += 2;
       start = position; // remember the start of the comment
+      let commentDepth = 1;
       currentChar = path.charAt(position);
-      while (!(currentChar === '*' && path.charAt(position + 1) === '/')) {
-        currentChar = path.charAt(++position);
+      while (commentDepth > 0) {
         if (position >= length) {
           // no closing tag
           throw {
@@ -247,6 +247,14 @@ export default function (path) {
           currentChar = path.charAt(position);
           lineStart = position;
           lineIndent = '';
+        } else if (currentChar === '/' && path.charAt(position + 1) === '*') {
+          commentDepth ++;
+          position += 2;
+          currentChar = path.charAt(position);
+        } else if (currentChar === '*' && path.charAt(position + 1) === '/') {
+          commentDepth --;
+          position += 2;
+          currentChar = path.charAt(position);
         } else if ('\r\n'.indexOf(currentChar) > -1) {
           // POSIX (\n) or old pre-OS X Macs Style (\r)
           position ++;
@@ -254,10 +262,10 @@ export default function (path) {
           currentChar = path.charAt(position);
           lineStart = position;
           lineIndent = '';
+        } else {
+          currentChar = path.charAt(++position);
         }
       }
-      position += 2;
-      currentChar = path.charAt(position);
       return next(hasLeftContext); // need this to swallow any following whitespace
     }
     start = position; // remember the start of the token

--- a/test/test-suite/groups/comments/fume004.json
+++ b/test/test-suite/groups/comments/fume004.json
@@ -1,0 +1,6 @@
+{
+    "expr-file": "fume004.jsonata",
+    "dataset": null,
+    "bindings": {},
+    "result": 1
+}

--- a/test/test-suite/groups/comments/fume004.jsonata
+++ b/test/test-suite/groups/comments/fume004.jsonata
@@ -1,0 +1,4 @@
+/* outer comment
+   /* nested comment */
+*/
+1

--- a/test/test-suite/groups/comments/fume005.json
+++ b/test/test-suite/groups/comments/fume005.json
@@ -1,0 +1,6 @@
+{
+    "expr-file": "fume005.jsonata",
+    "dataset": null,
+    "bindings": {},
+    "code": "F1103"
+}

--- a/test/test-suite/groups/comments/fume005.jsonata
+++ b/test/test-suite/groups/comments/fume005.jsonata
@@ -1,0 +1,4 @@
+/* outer comment
+   /* nested comment */
+*/;
+1


### PR DESCRIPTION
## Summary

Fix nested `/* ... */` block comment handling in the tokenizer so inner comment markers no longer terminate the outer comment early.

Fixes #63 

## What Changed

- Updated block-comment scanning in `src/utils/tokenizer.js` to track nested comment depth and exit only when the outermost block comment closes.
- Added regression coverage for nested block comments in the comments test-suite group.
- Preserved existing unterminated block-comment behavior and error reporting (`S0106`).

## Behavior

Before this change, a nested `/* ... */` pair inside a block comment could cause the tokenizer to resume too early and treat the remaining outer comment text as live code, leading to misleading parser or evaluator errors.

After this change, nested block comments are skipped correctly. Expressions that should continue after the comment now evaluate normally, and expressions that are still invalid after comment removal now surface the real parser error instead.

## Validation

- Built the package with `npm run build`
- Ran `npx mocha test/run-test-suite.test.js --timeout=20000 --grep "Group: comments"`
- Confirmed:
  - `fume004` passes with result `1`
  - `fume005` fails with `F1103`
  - existing unterminated comment coverage still passes with `S0106`